### PR TITLE
dracut-init: decompress kernel modules and firmware before final compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@
 /.buildpath
 /.project
 /Makefile.inc
+/dracut-cpio
 /dracut-install
 /dracut-util
 /dracut.conf.d/*.conf
 /dracut.pc
+/src/dracut-cpio/target
 /src/install/dracut-install
 /src/skipcpio/skipcpio
 /src/util/util

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "shfmt.executableArgs": [
+        "-s"
+    ]
+}

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1072,6 +1072,10 @@ dracut_kernel_post() {
         fi
     fi
 
+    if [[ $handle_precompress == decomp* ]]; then
+        dracut_kernel_post_decomp
+    fi
+
     for _f in modules.builtin modules.builtin.alias modules.builtin.modinfo modules.order; do
         [[ -e $srcmods/$_f ]] && inst_simple "$srcmods/$_f" "/lib/modules/$kernel/$_f"
     done
@@ -1082,7 +1086,71 @@ dracut_kernel_post() {
         dfatal "\"depmod -a $kernel\" failed."
         exit 1
     fi
+}
 
+dracut_kernel_post_decomp() {
+    # Check for the necessary find(1) command for post-processing.
+    if ! find_binary find &> /dev/null; then
+        derror "Will not process kernel modules and firmware as find(1) is not available!"
+        return 1
+    fi
+
+    # Check for necessary compression utilities.
+    local has_decomp has_ext=() cmd ext
+    for cmd in gzip:gz xz:xz zstd:zst; do
+        cmd=${cmd%:*}
+        ext=${cmd#*:}
+        if find_binary "$cmd" &> /dev/null; then
+            has_decomp+=" $cmd"
+            has_ext+=("$ext")
+        else
+            derror "Will not process kernel modules and firmware compressed with '$cmd' as the command is not available!"
+        fi
+    done
+    has_decomp+=" "
+
+    if [[ $has_decomp == " " ]]; then
+        derror "No decompression utilities available, skipping kernel module and firmware decompression!"
+        return 1
+    fi
+
+    # Decompress all firmware and module data for more optimal final
+    # compression ratio.
+    for kerndir in "${dstdir}/lib/firmware" \
+        "${dstdir}/lib/modules/$kernel"; do
+        [ -d "$kerndir" ] && find "$kerndir" -type f -print0 \
+            | while read -r -d $'\0' kernfile; do
+                case "$kernfile" in
+                    *.gz)
+                        ddebug "Decompressing gzipped kernel module/firmware: $kernfile ..."
+                        [[ $has_decomp == *" gzip "* ]] && gzip -d "$kernfile"
+                        ;;
+                    *.xz)
+                        ddebug "Decompressing xz-compressed kernel module/firmware: $kernfile ..."
+                        [[ $has_decomp == *" xz "* ]] && xz -d "$kernfile"
+                        ;;
+                    *.zst)
+                        ddebug "Decompressing zstd-compressed kernel module/firmware: $kernfile ..."
+                        [[ $has_decomp == *" zstd "* ]] && zstd -q --rm -d "$kernfile"
+                        ;;
+                esac
+            done
+    done
+
+    local findpat=(-name "*.${has_ext[0]}") i
+    for ((i = 1; i < ${#has_ext[@]}; i++)); do
+        findpat+=(-o -name "*.${has_ext[i]}")
+    done
+    # Fixup symlinks to compressed firmware.
+    [ -d "${dstdir}/lib/firmware" ] && find "${dstdir}/lib/firmware" \
+        \( "${findpat[@]}" \) \
+        -type l -print0 \
+        | while read -r -d $'\0' fwlink; do
+            ddebug "Fixing up decompressed firmware: $fwlink ..."
+            fwtarget=$(readlink "$fwlink")
+            rm "$fwlink"
+            ln -s "${fwtarget%.*}" "${fwlink%.*}"
+        done
 }
 
 instmods() {

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -66,13 +66,35 @@ fi
 
 cd /run/initramfs
 
-if (command -v zcat > /dev/null && $SKIP "$IMG" 2> /dev/null | zcat 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
-    || (command -v bzcat > /dev/null && $SKIP "$IMG" 2> /dev/null | bzcat 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
-    || (command -v xzcat > /dev/null && $SKIP "$IMG" 2> /dev/null | xzcat 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
-    || (command -v lz4 > /dev/null && $SKIP "$IMG" 2> /dev/null | lz4 -d -c 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
-    || (command -v lzop > /dev/null && $SKIP "$IMG" 2> /dev/null | lzop -d -c 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
-    || (command -v zstd > /dev/null && $SKIP "$IMG" 2> /dev/null | zstd -d -c 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1) \
-    || ($SKIP "$IMG" 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1); then
+decompress_unpack() {
+    for command in zcat bzcat xzcat lz4 lzop zstd; do
+        if command -v "$command" > /dev/null; then
+            if "$command" -d -c < "$1" 2> /dev/null | cpio -id --no-absolute-filenames --quiet > /dev/null 2>&1; then
+                did_decompress=1
+                return 0
+            fi
+        fi
+        cpio -id --no-absolute-filenames --quiet < "$1" > /dev/null 2>&1 && return 0
+    done
+}
+
+unpack() {
+    local did_decompress=0
+    $SKIP "$IMG" 2> /dev/null > /tmp/initramfs-restore-cpio.$$
+    decompress_unpack /tmp/initramfs-restore-cpio.$$
+
+    # Check for a second layer if this layer is not compressed
+    if ((did_decompress)) || [ "$SKIP" == "cat" ]; then
+        rm -f -- /tmp/initramfs-restore-cpio.$$
+        return
+    fi
+    $SKIP /tmp/initramfs-restore-cpio.$$ 2> /dev/null > /tmp/initramfs-restore-cpio2.$$
+    rm -f -- /tmp/initramfs-restore-cpio.$$
+    decompress_unpack /tmp/initramfs-restore-cpio2.$$
+    rm -f -- /tmp/initramfs-restore-cpio2.$$
+}
+
+if unpack; then
     rm -f -- .need_shutdown
 else
     # something failed, so we clean up

--- a/dracut.sh
+++ b/dracut.sh
@@ -2496,7 +2496,12 @@ create_cpio_file_lists() {
     if [[ $handle_precompress == split ]]; then
         # If we are not splitting the cpio, we do not need to create a separate
         # manifest for compressed files.
-        COMPRESS_PATTERN=(-false)
+        if [[ $(find . --version 2>&1) != *BusyBox* ]]; then
+            COMPRESS_PATTERN=(-false)
+        else
+            # Busybox find does not support -false, but it can be emulated:
+            COMPRESS_PATTERN=(-name /)
+        fi
     else
         # Inject an early_cpio marker file
         echo 2 > "$rootdir"/early_cpio

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -540,6 +540,13 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
     supported compressors and compressor specific options. If squash module is
     not called when building the initramfs, this option will not take effect.
 
+**--handle-precompress** _{no|split|decomp}_::
+    Control how already-compressed modules and firmware files are handled.
+    "decomp" will decompress already-compressed files before adding them to the
+    initramfs for better compression.  "split" (the default) will split the
+    files into a separate cpio archive that is not compressed for speed.
+    "no" does neither.
+
 **--no-compress**::
     Do not compress the generated initramfs. This will override any other
     compression options.

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -138,6 +138,18 @@ compressors and compressor specific options.
 If squash module is not called when building the initramfs,
 this option will not take effect.
 
+*handle_precompress=*"__{no|split|decomp}__"::
+Specify how to handle already-compressed firmware and kernel modules.
++
+If set to "no", do not handle pre-compressed files.
++
+If set to "split", split the pre-compressed files into a separate cpio archive
+that will not be compressed.  This saves time and almost does not cost extra space.
++
+If set to "decomp", decompress the pre-compressed files before they are put into
+the initramfs.  This makes the final compression step able to actually find
+a way to compress these modules, possibly saving some space at the cost of time.
+
 *do_strip=*"__{yes|no}__"::
 Strip binaries in the initramfs (default=yes).
 

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -67,13 +67,17 @@ test_setup() {
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man"
 
-    # shellcheck disable=SC2144 # We're not installing multilib libfido2, so
-    # glob will only match once. More matches would break the test anyway.
-    if pkg-config --exists "libsystemd >= 257" && [ -e /usr/lib*/libfido2.so.1 ] \
+    # shellcheck disable=SC2064
+    trap "$(shopt -p nullglob)" RETURN
+    shopt -q -s nullglob
+    declare -a fidos=(/usr/lib*/libfido2.so.1)
+    if pkg-config --exists "libsystemd >= 257" && ((${#fidos[@]})) \
         && ! lsinitrd "$TESTDIR"/initramfs.testing | grep -E ' usr/lib[^/]*/libfido2\.so\.1\b' > /dev/null; then
         echo "Error: libfido2.so.1 should have been included in the initramfs" >&2
+        lsinitrd "$TESTDIR"/initramfs.testing
         return 1
     fi
+
 }
 
 # shellcheck disable=SC1090

--- a/test/test-functions
+++ b/test/test-functions
@@ -59,9 +59,12 @@ test_dracut() {
     # shellcheck disable=SC2162
     IFS=' ' read -a TEST_DRACUT_ARGS_ARRAY <<< "$TEST_DRACUT_ARGS"
 
-    "$DRACUT" \
+    if ! "$DRACUT" \
         "${TEST_DRACUT_ARGS_ARRAY[@]}" \
-        "$@" "$TESTDIR"/initramfs.testing || return 1
+        "$@" "$TESTDIR"/initramfs.testing; then
+        lsinitrd "$TESTDIR"/initramfs.testing
+        return 1
+    fi
 }
 
 # Wait for the server QEMU has been started up.


### PR DESCRIPTION
This pull request changes...

## Changes

Decompress all kernel modules and firmware (if compressed), this allows for better compression ratio as we make the compressed initramfs.

This may save over 10MiB post-XZ.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it