### PR TITLE
feat(50-dracut.install): skip installation if zfs required but missing

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -41,6 +41,14 @@ if [[ -f ${KERNEL_IMAGE%/*}/$IMAGE ]]; then
         && exit 0
 fi
 
+# Skip kernel installation if zfs has not been built yet
+if (grep ' / ' /proc/mounts | grep -q zfs) && ! modinfo zfs -k "${KERNEL_VERSION}" &>/dev/null
+then
+     [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo \
+        "root is zfs, but the zfs module is missing, please build the zfs module and retry"
+    exit 77
+fi
+
 if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
     if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
         read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"


### PR DESCRIPTION
On some distributions external kernel modules are built after the kernel package has been installed, this is usually required since building the external kernel modules requires part of the sources for that kernel version.

This presents us with the following problem, after the install of the kernel package /sbin/installkernel is run but dracut cannot yet create a functional initramfs if the root is zfs since the zfs module has not been built. Dracut however does not treat this as a fatal failure and creates an initramfs anyway.

The package manager should schedule zfs for (re-)installation for the new kernel version and then (re-)trigger /sbin/installkernel for another run. On this second run a functional initramfs is installed.

However, if there is some interruption between the first and second run of /sbin/installkernel then we are left with a broken kernel+initramfs that is installed and presumably registered with the bootloader. Rebooting the system in this state would create a mess.

I therefore propose the following solution, we check here if the root is zfs, and if we can find the zfs module for this kernel version. If not then we exit with the special exit code 77. This exit code causes kernel- install to skip all remaining plugins and hence effectively prevents the (broken) kernel from being installed and registered with the bootloader. Exit code 77 is not fatal and therefore the process calling /sbin/installkernel (i.e. make or the package manager) will continue the update process and update the external kernel modules.

On the second call to /sbin/installkernel by the package manager the check for zfs will now pass and the working kernel+initramfs is installed.

In distributions that somehow install the zfs module before calling /sbin/installkernel this check would be redundant and does nothing.

If the zfs module is managed via dkms, the dkms hook is run before the dracut hook (number 45 versus 50) and therefore the zfs module should already be present at this stage and the added check does nothing.

We do not have to duplicate this check in the rescue hook since the special exit code 77 would cause it to be skipped anyway if the new check is triggered.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
