### PR TITLE
feat: Put compressed kernel modules and firmware in an uncompressed cpio

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3120,6 +3120,41 @@ fi
 
 dinfo "*** Creating image file '$outfile' ***"
 
+# Read list of files and echo them plus all leading directories.
+# The same directories might be printed multiple times (even with sorted input)!
+add_directories() {
+    local last_dir path dir
+    while read -r path; do
+        dir="${path%/*}"
+        parent="${dir}"
+        while [ "$parent" != "$last_dir" ] && [ "$parent" != "." ]; do
+            echo "$parent"
+            parent="${parent%/*}"
+        done
+        last_dir="$dir"
+        echo "$path"
+    done
+    if [ -n "$last_dir" ]; then
+        echo "."
+    fi
+}
+
+create_cpio_file_lists() {
+    local rootdir="$1"
+    local compressed_file_list="$2"
+    local uncompressed_file_list="$3"
+
+    (
+        cd "$rootdir" || exit 1
+        find . -type f \( -name '*.gz' -o -name '*.xz' -o -name '*.zst' \)
+    ) | add_directories | LC_ALL=C sort | uniq > "$compressed_file_list"
+    (
+        cd "$rootdir" || exit 1
+        find . \( ! -type d ! -name '*.gz' ! -name '*.xz' ! -name '*.zst' \) \
+            -o \( ! -type d ! -type f \) -o \( -type d -empty \)
+    ) | add_directories | LC_ALL=C sort | uniq > "$uncompressed_file_list"
+}
+
 if [[ $uefi == yes ]]; then
     readonly uefi_outdir="$DRACUT_TMPDIR/uefi"
     mkdir -p "$uefi_outdir"
@@ -3158,14 +3193,19 @@ fi
 [[ $EUID == 0 ]] || owner_override="\t\t\t0\t0"
 path_to_manifest() {
     local basedir="$1"
-    local relpath
+    local fullpath relpath
     while IFS= read -r path; do
-        if [[ $path == "$basedir" ]]; then
+        if [[ $path == "$basedir" ]] || [[ $path == . ]]; then
             relpath=.
+            fullpath="$basedir"
+        elif [[ $path =~ \./.* ]]; then
+            relpath="${path#./}"
+            fullpath="$basedir/$relpath"
         else
             relpath="${path#"$basedir"/}"
+            fullpath="$path"
         fi
-        printf "%s\t%s${owner_override-}\n" "$path" "${relpath}"
+        printf "%s\t%s${owner_override-}\n" "${fullpath}" "${relpath}"
     done
 }
 
@@ -3320,12 +3360,23 @@ create_cpio_with_dracut_cpio() {
         cpio_outfile="${DRACUT_TMPDIR}/initramfs.img.uncompressed"
     fi
 
+    if [ -s "$COMPRESSED_FILE_LIST" ]; then
+        if ! (
+            umask 077
+            cd "$initdir"
+            $enhanced_cpio ${cpio_owner:+--owner "$cpio_owner"} --mtime 0 --data-align \
+                "$cpio_align" "${DRACUT_TMPDIR}/initramfs.img" < "$COMPRESSED_FILE_LIST"
+        ); then
+            dfatal "dracut-cpio: creation of $outfile failed"
+            exit 1
+        fi
+    fi
+
     if ! (
         umask 077
         cd "$initdir"
-        find . -print0 | sort -z \
-            | $enhanced_cpio --null ${cpio_owner:+--owner "$cpio_owner"} \
-                --mtime 0 --data-align "$cpio_align" "$cpio_outfile" || exit 1
+        $enhanced_cpio ${cpio_owner:+--owner "$cpio_owner"} --mtime 0 --data-align \
+            "$cpio_align" "$cpio_outfile" < "$UNCOMPRESSED_FILE_LIST" || exit 1
         [[ $compress == "cat" ]] && exit 0
         $compress < "$cpio_outfile" >> "${DRACUT_TMPDIR}/initramfs.img" \
             && rm "$cpio_outfile"
@@ -3337,12 +3388,16 @@ create_cpio_with_dracut_cpio() {
 }
 
 create_cpio_with_3cpio() {
+    if [ -s "$COMPRESSED_FILE_LIST" ]; then
+        echo "#cpio" >> "$manifest"
+        path_to_manifest "$initdir" < "$COMPRESSED_FILE_LIST" >> "$manifest"
+    fi
     if [[ -z $compress_3cpio ]]; then
         echo "#cpio" >> "$manifest"
     else
         echo "#cpio: $compress_3cpio" >> "$manifest"
     fi
-    find "$initdir" | LANG=C sort | path_to_manifest "$initdir" >> "$manifest"
+    path_to_manifest "$initdir" < "$UNCOMPRESSED_FILE_LIST" >> "$manifest"
     if ! 3cpio --create ${cpio_align:+--data-align="${cpio_align}"} "${DRACUT_TMPDIR}/initramfs.img" < "$manifest"; then
         dfatal "Creation of $outfile failed"
         exit 1
@@ -3350,17 +3405,32 @@ create_cpio_with_3cpio() {
 }
 
 create_cpio_with_cpio() {
+    if [ -s "$COMPRESSED_FILE_LIST" ]; then
+        if ! (
+            umask 077
+            cd "$initdir"
+            cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
+                < "$COMPRESSED_FILE_LIST" >> "${DRACUT_TMPDIR}/initramfs.img"
+        ); then
+            dfatal "Creation of $outfile failed"
+            exit 1
+        fi
+    fi
+
     if ! (
         umask 077
         cd "$initdir"
-        find . -print0 | sed -e 's,\./,,g' | sort -z \
-            | cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} --null ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
-            | $compress >> "${DRACUT_TMPDIR}/initramfs.img"
+        cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
+            < "$UNCOMPRESSED_FILE_LIST" | $compress >> "${DRACUT_TMPDIR}/initramfs.img"
     ); then
         dfatal "Creation of $outfile failed"
         exit 1
     fi
 }
+
+COMPRESSED_FILE_LIST="$DRACUT_TMPDIR/compressed_files.txt"
+UNCOMPRESSED_FILE_LIST="$DRACUT_TMPDIR/uncompressed_files.txt"
+create_cpio_file_lists "$initdir" "$COMPRESSED_FILE_LIST" "$UNCOMPRESSED_FILE_LIST"
 
 if [[ -n $enhanced_cpio ]]; then
     create_cpio_with_dracut_cpio

--- a/dracut.sh
+++ b/dracut.sh
@@ -3135,6 +3135,41 @@ fi
 
 dinfo "*** Creating image file '$outfile' ***"
 
+# Read list of files and echo them plus all leading directories.
+# The same directories might be printed multiple times (even with sorted input)!
+add_directories() {
+    local last_dir parent path dir
+    while IFS= read -r path; do
+        dir="${path%/*}"
+        parent="${dir}"
+        while [ "$parent" != "$last_dir" ] && [ "$parent" != "." ]; do
+            echo "$parent"
+            parent="${parent%/*}"
+        done
+        last_dir="$dir"
+        echo "$path"
+    done
+    if [ -n "$last_dir" ]; then
+        echo "."
+    fi
+}
+
+create_cpio_file_lists() {
+    local rootdir="$1"
+    local compressed_file_list="$2"
+    local uncompressed_file_list="$3"
+
+    (
+        cd "$rootdir" || exit 1
+        find . -type f \( -name '*.gz' -o -name '*.xz' -o -name '*.zst' \)
+    ) | add_directories | LC_ALL=C sort -u > "$compressed_file_list"
+    (
+        cd "$rootdir" || exit 1
+        find . \( ! -type d ! -name '*.gz' ! -name '*.xz' ! -name '*.zst' \) \
+            -o \( ! -type d ! -type f \) -o \( -type d -empty \)
+    ) | add_directories | LC_ALL=C sort -u > "$uncompressed_file_list"
+}
+
 if [[ $uefi == yes ]]; then
     readonly uefi_outdir="$DRACUT_TMPDIR/uefi"
     mkdir -p "$uefi_outdir"
@@ -3173,14 +3208,19 @@ fi
 [[ $EUID == 0 ]] || owner_override="\t\t\t0\t0"
 path_to_manifest() {
     local basedir="$1"
-    local relpath
+    local fullpath relpath
     while IFS= read -r path; do
-        if [[ $path == "$basedir" ]]; then
+        if [[ $path == "$basedir" ]] || [[ $path == . ]]; then
             relpath=.
+            fullpath="$basedir"
+        elif [[ $path =~ \./.* ]]; then
+            relpath="${path#./}"
+            fullpath="$basedir/$relpath"
         else
             relpath="${path#"$basedir"/}"
+            fullpath="$path"
         fi
-        printf "%s\t%s${owner_override-}\n" "$path" "${relpath}"
+        printf "%s\t%s${owner_override-}\n" "${fullpath}" "${relpath}"
     done
 }
 
@@ -3335,12 +3375,23 @@ create_cpio_with_dracut_cpio() {
         cpio_outfile="${DRACUT_TMPDIR}/initramfs.img.uncompressed"
     fi
 
+    if [ -s "$COMPRESSED_FILE_LIST" ]; then
+        if ! (
+            umask 077
+            cd "$initdir"
+            $enhanced_cpio ${cpio_owner:+--owner "$cpio_owner"} --mtime 0 --data-align \
+                "$cpio_align" "${DRACUT_TMPDIR}/initramfs.img" < "$COMPRESSED_FILE_LIST"
+        ); then
+            dfatal "dracut-cpio: creation of $outfile failed"
+            exit 1
+        fi
+    fi
+
     if ! (
         umask 077
         cd "$initdir"
-        find . -print0 | sort -z \
-            | $enhanced_cpio --null ${cpio_owner:+--owner "$cpio_owner"} \
-                --mtime 0 --data-align "$cpio_align" "$cpio_outfile" || exit 1
+        $enhanced_cpio ${cpio_owner:+--owner "$cpio_owner"} --mtime 0 --data-align \
+            "$cpio_align" "$cpio_outfile" < "$UNCOMPRESSED_FILE_LIST" || exit 1
         [[ $compress == "cat" ]] && exit 0
         $compress < "$cpio_outfile" >> "${DRACUT_TMPDIR}/initramfs.img" \
             && rm "$cpio_outfile"
@@ -3352,12 +3403,16 @@ create_cpio_with_dracut_cpio() {
 }
 
 create_cpio_with_3cpio() {
+    if [ -s "$COMPRESSED_FILE_LIST" ]; then
+        echo "#cpio" >> "$manifest"
+        path_to_manifest "$initdir" < "$COMPRESSED_FILE_LIST" >> "$manifest"
+    fi
     if [[ -z $compress_3cpio ]]; then
         echo "#cpio" >> "$manifest"
     else
         echo "#cpio: $compress_3cpio" >> "$manifest"
     fi
-    find "$initdir" | LANG=C sort | path_to_manifest "$initdir" >> "$manifest"
+    path_to_manifest "$initdir" < "$UNCOMPRESSED_FILE_LIST" >> "$manifest"
     if ! 3cpio --create ${cpio_align:+--data-align="${cpio_align}"} "${DRACUT_TMPDIR}/initramfs.img" < "$manifest"; then
         dfatal "Creation of $outfile failed"
         exit 1
@@ -3365,17 +3420,32 @@ create_cpio_with_3cpio() {
 }
 
 create_cpio_with_cpio() {
+    if [ -s "$COMPRESSED_FILE_LIST" ]; then
+        if ! (
+            umask 077
+            cd "$initdir"
+            cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
+                < "$COMPRESSED_FILE_LIST" >> "${DRACUT_TMPDIR}/initramfs.img"
+        ); then
+            dfatal "Creation of $outfile failed"
+            exit 1
+        fi
+    fi
+
     if ! (
         umask 077
         cd "$initdir"
-        find . -print0 | sed -e 's,\./,,g' | sort -z \
-            | cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} --null ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
-            | $compress >> "${DRACUT_TMPDIR}/initramfs.img"
+        cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
+            < "$UNCOMPRESSED_FILE_LIST" | $compress >> "${DRACUT_TMPDIR}/initramfs.img"
     ); then
         dfatal "Creation of $outfile failed"
         exit 1
     fi
 }
+
+COMPRESSED_FILE_LIST="$DRACUT_TMPDIR/compressed_files.txt"
+UNCOMPRESSED_FILE_LIST="$DRACUT_TMPDIR/uncompressed_files.txt"
+create_cpio_file_lists "$initdir" "$COMPRESSED_FILE_LIST" "$UNCOMPRESSED_FILE_LIST"
 
 if [[ -n $enhanced_cpio ]]; then
     create_cpio_with_dracut_cpio


### PR DESCRIPTION
Dracut compresses all files that are put into the initramfs. Kernel modules and firmware files might already be compressed. Compressing those files will not give any size savings.

## Changes

So put compressed kernel modules and firmware files in an uncompressed cpio instead. This will speed up the initrd generation and extraction without a significant size change of the initrd.

See
https://salsa.debian.org/kernel-team/initramfs-tools/-/merge_requests/128 and https://lists.ubuntu.com/archives/ubuntu-devel/2023-July/042707.html for a similar change in initramfs-tools.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/110
