### PR TITLE
feat(dracut): set no_kernel to "yes" for CONFIG_MODULES=n

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1419,6 +1419,12 @@ esac
 hostonly=${hostonly-}
 hostonly_mode=${hostonly_mode-}
 
+# when no_kernel is not specified in hostonly mode and /proc/modules does not exists,
+# set no_kernel to yes
+if [[ $no_kernel ]] && [[ $hostonly ]] && ! [[ -e /proc/modules ]]; then
+    no_kernel="yes"
+fi
+
 if [[ $reproducible == yes ]] && [[ -z ${SOURCE_DATE_EPOCH-} ]]; then
     SOURCE_DATE_EPOCH=$(stat -c %Y "$dracutbasedir/dracut-functions.sh")
     export SOURCE_DATE_EPOCH


### PR DESCRIPTION
## Changes

For a monolithic kernel (CONFIG_MODULES=n), when no_kernel is not set, initialize no_kernel to "yes".

This change further improve usability for monolithic kernel users.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
