### PR TITLE
fix(dracut): only take --hostonly-cmdline into account in host-only mode

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -192,7 +192,7 @@ Creates initial ramdisk images for preloading modules
                          DO NOT use "strict" mode unless you know what you
                          are doing.
   --hostonly-cmdline    Store kernel command line arguments needed
-                         in the initramfs.
+                         in the initramfs if in host-only mode.
   --no-hostonly-cmdline Do not store kernel command line arguments needed
                          in the initramfs.
   --no-hostonly-default-device
@@ -1138,7 +1138,6 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $hostonly_l ]] && hostonly=$hostonly_l
 [[ $hostonly_cmdline_l ]] && hostonly_cmdline=$hostonly_cmdline_l
 [[ $hostonly_mode_l ]] && hostonly_mode=$hostonly_mode_l
-[[ ${hostonly-} == "yes" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"
 # shellcheck disable=SC2034
 [[ $i18n_install_all_l ]] && i18n_install_all=$i18n_install_all_l
 # shellcheck disable=SC2034
@@ -1372,6 +1371,12 @@ esac
 # make sure these variables are never unset
 hostonly=${hostonly-}
 hostonly_mode=${hostonly_mode-}
+
+if [[ ! $hostonly ]]; then
+    hostonly_cmdline="no"
+elif [[ ! $hostonly_cmdline ]]; then
+    hostonly_cmdline="yes"
+fi
 
 if [[ $reproducible == yes ]] && [[ -z ${SOURCE_DATE_EPOCH-} ]]; then
     SOURCE_DATE_EPOCH=$(stat -c %Y "$dracutbasedir/dracut-functions.sh")

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -398,6 +398,7 @@ Default:
 
 **--hostonly-cmdline**::
     Allow dracut modules to generate and store host-specific initrd arguments.
+    This option is only taken into account when in host-only mode.
     These arguments will be stored in the _etc/cmdline.d_ directory inside
     the generated initrd.
     The kernel cmdline arguments (specified by e.g. bootloader or UKI) take

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -194,8 +194,7 @@ the image unbootable.
 
 *hostonly_cmdline=*"__{yes|no}__"::
 If set to "yes", store the kernel command line arguments needed in the
-initramfs. If **hostonly="yes"** and this option is not configured, it's
-automatically set to "yes". (default=no)
+initramfs if in host-only mode. (default=yes)
 
 *hostonly_nics+=*" [__<nic>__[ __<nic>__ ...]] "::
 Only enable listed NICs in the initramfs. The list can be empty, so other


### PR DESCRIPTION
When building an initrd with `--no-hostonly`, the parameter `--hostonly-cmdline` is still taken into account. That is
counter-intiutive.

So only take `--hostonly-cmdline`/`hostonly_cmdline` into account in host-only mode.

The default stays the same: the cmdline is included in `hostonly=yes` mode and not included in `hostonly=no` mode.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
