### PR TITLE
feat(dracut): add module to load Qualcomm ADSP module pre-udev

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -379,6 +379,10 @@ qemu-net:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu-net/*'
 
+qcom-adsp:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qcom-adsp/*'
+
 systemd-cryptsetup:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-cryptsetup/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -372,6 +372,10 @@ ppcmac:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]ppcmac/*'
 
+qcom-adsp:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qcom-adsp/*'
+
 qemu:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu/*'

--- a/doc_site/modules/ROOT/pages/modules/core.adoc
+++ b/doc_site/modules/ROOT/pages/modules/core.adoc
@@ -201,6 +201,10 @@ code, there are no specific types or categories for dracut modules.
 | polls CD-ROM
 |
 
+| qcom-adsp
+| Load Qualcomm ADSP module pre-udev
+|
+
 | rescue
 | utilities for rescue mode (such as ping, ssh, vi, fsck.*)
 | utils

--- a/doc_site/modules/ROOT/pages/modules/core.adoc
+++ b/doc_site/modules/ROOT/pages/modules/core.adoc
@@ -193,6 +193,10 @@ code, there are no specific types or categories for dracut modules.
 | polls CD-ROM
 |
 
+| qcom-adsp
+| Load Qualcomm ADSP module pre-udev
+|
+
 | rescue
 | utilities for rescue mode (such as ping, ssh, vi, fsck.*)
 | utils

--- a/modules.d/70qcom-adsp/module-setup.sh
+++ b/modules.d/70qcom-adsp/module-setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# On Qualcomm sc8280xp and x1e laptops the kernel reboots the ADSP with new
+# firmware because the BIOS loads ADSP firmware with limited functionality
+# without sound or battery charge/status reading support.
+#
+# Unfortunately the ADSP also controls the TCPM (Type-C Port Manager) and
+# rebooting the ADSP also resets the TCPM, causing any USB devices connected
+# over Type-C ports to get disconnected as all devices on the USB bus are
+# removed and re-enumerated.
+#
+# This breaks booting from USB-drives as the drive gets disconnected and
+# re-enumerated as a new block device, leaving any filesystems mounted
+# before the ADSP reset without any backing device.
+#
+# To workaround this, this module load the ADSP driver from a pre-udev hook
+# so that the USB re-enumeration happens before the rootfs is mounted.
+
+# called by dracut
+check() {
+    [ "$DRACUT_ARCH" = "aarch64" ] || return 1
+    if [[ $hostonly ]]; then
+        grep -q -E 'qcom,sc8280xp-adsp-pas|qcom,x1e80100-adsp-pas' \
+            /sys/bus/platform/devices/*.remoteproc/modalias 2> /dev/null || return 1
+    fi
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods qcom_q6v5_pas
+}
+
+# called by dracut
+install() {
+    inst_hook pre-udev 30 "$moddir/qcom-adsp-pre-udev.sh"
+}

--- a/modules.d/70qcom-adsp/module-setup.sh
+++ b/modules.d/70qcom-adsp/module-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# On Qualcomm sc8280xp and x1e laptops the kernel reboots the ADSP with new
+# firmware because the BIOS loads ADSP firmware with limited functionality
+# without sound or battery charge/status reading support.
+#
+# Unfortunately the ADSP also controls the TCPM (Type-C Port Manager) and
+# rebooting the ADSP also resets the TCPM, causing any USB devices connected
+# over Type-C ports to get disconnected as all devices on the USB bus are
+# removed and re-enumerated.
+#
+# This breaks booting from USB-drives as the drive gets disconnected and
+# re-enumerated as a new block device, leaving any filesystems mounted
+# before the ADSP reset without any backing device.
+#
+# To workaround this, this module load the ADSP driver from a pre-udev hook
+# so that the USB re-enumeration happens before the rootfs is mounted.
+
+# called by dracut
+check() {
+    [ "$DRACUT_ARCH" = "aarch64" ] || return 1
+    if [[ $hostonly_mode == "strict" ]]; then
+        grep -q -E 'qcom,sc8280xp-adsp-pas|qcom,x1e80100-adsp-pas' \
+            /sys/bus/platform/devices/*.remoteproc/modalias 2> /dev/null || return 1
+    fi
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods qcom_q6v5_pas
+}
+
+# called by dracut
+install() {
+    inst_multiple grep modprobe
+    inst_hook pre-udev 30 "$moddir/qcom-adsp-pre-udev.sh"
+}

--- a/modules.d/70qcom-adsp/qcom-adsp-pre-udev.sh
+++ b/modules.d/70qcom-adsp/qcom-adsp-pre-udev.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Ensure ADSP module is loaded and Type-C USB busses are reset before
+# filesystems are mounted
+
+if grep -q -E 'qcom,sc8280xp-adsp-pas|qcom,x1e80100-adsp-pas' \
+    /sys/bus/platform/devices/*.remoteproc/modalias 2> /dev/null; then
+    modprobe qcom_q6v5_pas
+fi


### PR DESCRIPTION
On Qualcomm sc8280xp and x1e laptops the kernel reboots the ADSP with new firmware because the BIOS loads ADSP firmware with limited functionality without sound or battery charge/status reading support.

Unfortunately the ADSP also controls the TCPM (Type-C Port Manager) and rebooting the ADSP also resets the TCPM, causing any USB devices connected over Type-C ports to get disconnected as all devices on the USB bus are removed and re-enumerated.

This breaks booting from USB-drives as the drive gets disconnected and re-enumerated as a new block device, leaving any filesystems mounted before the ADSP reset without any backing device.

To workaround this add a module to load the ADSP driver from a pre-udev hook so that the USB re-enumeration happens before the rootfs is mounted.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code for it
