### PR TITLE
dracut-ng: enhance rd.cmdline=ask prompt visibility and robustness

### DIFF
--- a/modules.d/77dracut-systemd/dracut-cmdline-ask.sh
+++ b/modules.d/77dracut-systemd/dracut-cmdline-ask.sh
@@ -4,21 +4,37 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 getarg "rd.cmdline=ask" || exit 0
 
-sleep 0.5
-echo
-sleep 0.5
-echo
-sleep 0.5
-echo
-echo
-echo
-echo
-echo "Enter additional kernel command line parameter (end with ctrl-d or .)"
+sleep 0.25
+echo ""
+sleep 0.25
+echo "    ========================================================================    "
+sleep 0.25
+echo '(o<                                                                          >o)'
+sleep 0.25
+echo '//\                        INPUT REQUIRED !!!                                /\\'
+sleep 0.25
+echo 'V_/_                                                                        _\_V'
+sleep 0.25
+echo "    ========================================================================    "
+sleep 0.25
+echo ""
+sleep 0.25
+echo ' Enter additional kernel command line, or install program, parameters.'
+sleep 0.25
+echo ' End with a period "." or Ctrl+d in a new line:'
+sleep 0.25
+
+# Ignore Ctrl+c (the d key is too close to c)
+trap '' SIGINT
+
 # In POSIX sh, read -p is undefined, but dash supports it
 # shellcheck disable=SC3045
 while read -r -p "> " ${BASH:+-e} line || [ -n "$line" ]; do
     [ "$line" = "." ] && break
     [ -n "$line" ] && printf -- "%s\n" "$line" >> /etc/cmdline.d/99-cmdline-ask.conf
 done
+
+# Restore Ctrl+c
+trap 'exit 2;' SIGINT
 
 exit 0

--- a/modules.d/80base/init.sh
+++ b/modules.d/80base/init.sh
@@ -110,13 +110,38 @@ fi
 source_conf /etc/conf.d
 
 if getarg "rd.cmdline=ask"; then
-    echo "Enter additional kernel command line parameter (end with ctrl-d or .)"
+    sleep 0.25
+    echo ""
+    sleep 0.25
+    echo "    ========================================================================    "
+    sleep 0.25
+    echo '(o<                                                                          >o)'
+    sleep 0.25
+    echo '//\                        INPUT REQUIRED !!!                                /\\'
+    sleep 0.25
+    echo 'V_/_                                                                        _\_V'
+    sleep 0.25
+    echo "    ========================================================================    "
+    sleep 0.25
+    echo ""
+    sleep 0.25
+    echo ' Enter additional kernel command line, or install program, parameters.'
+    sleep 0.25
+    echo ' End with a period "." or Ctrl+d in a new line:'
+    sleep 0.25
+
+    # Ignore Ctrl+c (the d key is too close to c)
+    trap '' SIGINT
+
     # In POSIX sh, read -p is undefined, but dash supports it
     # shellcheck disable=SC3045
     while read -r -p "> " ${BASH:+-e} line || [ -n "$line" ]; do
         [ "$line" = "." ] && break
         echo "$line" >> /etc/cmdline.d/99-cmdline-ask.conf
     done
+
+    # Restore Ctrl+c
+    trap 'exit 2;' SIGINT
 fi
 
 if ! getargbool 1 'rd.hostonly'; then


### PR DESCRIPTION
The current "rd.cmdline=ask" prompt is very easy to miss during the boot process, as it's just a single line of text that often gets buried among other kernel messages.

It improves the user experience by:
- Adding a high-visibility 80-column ASCII banner to clearly signal that input is required.
- Refining the text to clarify that both kernel and install program parameters are accepted.
- Implementing a temporary 'trap' for SIGINT (Ctrl+c). Since the 'd' key is physically close to 'c' on most layouts, it's easy to accidentally kill the script when trying to send EOF (Ctrl+d).
- Using shorter, consistent sleep intervals for a smoother rendering of the banner.

Old prompt:
`Enter additional kernel command line parameter (end with ctrl-d or .)`

New prompt:
```
    ========================================================================
(o<                                                                          >o)
//\                        INPUT REQUIRED !!!                                /\\
V_/_                                                                        _\_V
    ========================================================================

 Enter additional kernel command line, or install program, parameters.
 End with a period "." or Ctrl+d in a new line:
```
<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
