### PR TITLE
feat(crypt-gpg): add a parameter for GPG password max tries

### DIFF
--- a/modules.d/70crypt-lib/crypt-lib.sh
+++ b/modules.d/70crypt-lib/crypt-lib.sh
@@ -118,12 +118,17 @@ ask_for_password() {
             fi
 
             local i=1
-            while [ $i -le "$tty_tries" ]; do
-                [ -n "$tty_prompt" ] \
-                    && printf "%s" "$tty_prompt [$i/$tty_tries]:" >&2
+            while [ 0 -eq "$tty_tries" ] || [ $i -le "$tty_tries" ]; do
+                if [ -n "$tty_prompt" ]; then
+                    printf "%s" "$tty_prompt" >&2
+                    if [ 0 -ne "$tty_tries" ] ; then
+                        printf "%s" " [$i/$tty_tries]" >&2
+                    fi
+                    printf "%s" ":" >&2
+                fi
                 eval "$tty_cmd" && ret=0 && break
                 ret=$?
-                i=$((i + 1))
+                [ 0 -ne "$tty_tries" ] && i=$((i + 1))
                 [ -n "$tty_prompt" ] && printf '\n' >&2
             done
 
@@ -272,7 +277,7 @@ readkey() {
         gpg)
             if [ -f /lib/dracut-crypt-gpg-lib.sh ]; then
                 . /lib/dracut-crypt-gpg-lib.sh
-                gpg_decrypt "$mntp" "$keypath" "$keydev" "$device"
+                gpg_decrypt "$mntp" "$keypath" "$keydev" "$device" "$(getarg rd.luks.key.max-tries)"
             else
                 die "No GPG support to decrypt '$keypath' on '$keydev'."
             fi

--- a/modules.d/70crypt-lib/crypt-lib.sh
+++ b/modules.d/70crypt-lib/crypt-lib.sh
@@ -121,7 +121,7 @@ ask_for_password() {
             while [ 0 -eq "$tty_tries" ] || [ $i -le "$tty_tries" ]; do
                 if [ -n "$tty_prompt" ]; then
                     printf "%s" "$tty_prompt" >&2
-                    if [ 0 -ne "$tty_tries" ] ; then
+                    if [ 0 -ne "$tty_tries" ]; then
                         printf "%s" " [$i/$tty_tries]" >&2
                     fi
                     printf "%s" ":" >&2

--- a/modules.d/73crypt-gpg/crypt-gpg-lib.sh
+++ b/modules.d/73crypt-gpg/crypt-gpg-lib.sh
@@ -15,6 +15,7 @@ gpg_decrypt() {
     local keypath="$2"
     local keydev="$3"
     local device="$4"
+    local maxTries="$5"
 
     local gpghome=/tmp/gnupg
     local opts="--homedir $gpghome --no-mdc-warning --skip-verify --quiet"
@@ -59,7 +60,7 @@ gpg_decrypt() {
     ask_for_password \
         --cmd "$cmd" \
         --prompt "${inputPrompt:-Password ($keypath on $keydev for $device)}" \
-        --tries 3 --tty-echo-off
+        --tries "${maxTries:-3}" --tty-echo-off
 
     # Clean up the smartcard gpg-agent
     if [ "${useSmartcard}" = "1" ]; then


### PR DESCRIPTION
This adds the rd.luks.key.max-tries parameter that specifies the number of times that dracut will prompt for a GPG password before falling back to passphrase decryption. Previously, the number of tries was hardcoded to be 3, but this parameter lets the user customize it. In particular, if rd.luks.key.max-tries is set to 0, dracut will re-prompt for the GPG password forever and will not try to fall back to a passphrase. If rd.luks.key.max-tries is not specified, the default value is 3.