### PR TITLE
fix(dracut-rescue): use entry token instead of machine-id for path construction

### DIFF
--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -66,6 +66,8 @@ if ! [[ $MACHINE_ID ]]; then
     exit 0
 fi
 
+ENTRY_TOKEN="${KERNEL_INSTALL_ENTRY_TOKEN:-${MACHINE_ID}}"
+
 if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
     if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
         read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
@@ -85,15 +87,15 @@ else
 fi
 
 if [[ -d ${BOOT_DIR_ABS%/*} ]]; then
-    BOOT_DIR="/${MACHINE_ID}/0-rescue"
+    BOOT_DIR="/${ENTRY_TOKEN}/0-rescue"
     BOOT_ROOT=${BOOT_DIR_ABS%"$BOOT_DIR"}
-    LOADER_ENTRY="$BOOT_ROOT/loader/entries/${MACHINE_ID}-0-rescue.conf"
+    LOADER_ENTRY="$BOOT_ROOT/loader/entries/${ENTRY_TOKEN}-0-rescue.conf"
     KERNEL="linux"
     INITRD="initrd"
 else
     BLS_DIR="/boot/loader/entries"
     BOOT_DIR_ABS="/boot"
-    LOADER_ENTRY="$BLS_DIR/${MACHINE_ID}-0-rescue.conf"
+    LOADER_ENTRY="$BLS_DIR/${ENTRY_TOKEN}-0-rescue.conf"
     KERNEL="vmlinuz-0-rescue-${MACHINE_ID}"
     INITRD="initramfs-0-rescue-${MACHINE_ID}.img"
 fi
@@ -150,8 +152,8 @@ case "$COMMAND" in
                 echo "initrd     $BOOT_DIR/initrd"
             } > "$LOADER_ENTRY"
         else
-            if [[ -e "${BLS_DIR}/${MACHINE_ID}-${KERNEL_VERSION}.conf" ]]; then
-                cp -aT "${BLS_DIR}/${MACHINE_ID}-${KERNEL_VERSION}.conf" "$LOADER_ENTRY"
+            if [[ -e "${BLS_DIR}/${ENTRY_TOKEN}-${KERNEL_VERSION}.conf" ]]; then
+                cp -aT "${BLS_DIR}/${ENTRY_TOKEN}-${KERNEL_VERSION}.conf" "$LOADER_ENTRY"
             else
                 cp -aT "${KERNEL_IMAGE%/*}/bls.conf" "$LOADER_ENTRY"
             fi

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -66,6 +66,14 @@ if ! [[ $MACHINE_ID ]]; then
     exit 0
 fi
 
+# The entry token (systemd 253+) is used for the boot directory and loader
+# entry paths, since kernel-install derives those from it. The rescue image
+# *filenames* below deliberately keep $MACHINE_ID: it guarantees per-machine
+# uniqueness (entry tokens such as os-id/os-image-id can be shared across
+# parallel installs of the same OS), and the BLS "machine-id" field must be
+# the machine ID by spec.
+ENTRY_TOKEN="${KERNEL_INSTALL_ENTRY_TOKEN:-${MACHINE_ID}}"
+
 if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
     if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
         read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
@@ -85,15 +93,15 @@ else
 fi
 
 if [[ -d ${BOOT_DIR_ABS%/*} ]]; then
-    BOOT_DIR="/${MACHINE_ID}/0-rescue"
+    BOOT_DIR="/${ENTRY_TOKEN}/0-rescue"
     BOOT_ROOT=${BOOT_DIR_ABS%"$BOOT_DIR"}
-    LOADER_ENTRY="$BOOT_ROOT/loader/entries/${MACHINE_ID}-0-rescue.conf"
+    LOADER_ENTRY="$BOOT_ROOT/loader/entries/${ENTRY_TOKEN}-0-rescue.conf"
     KERNEL="linux"
     INITRD="initrd"
 else
     BLS_DIR="/boot/loader/entries"
     BOOT_DIR_ABS="/boot"
-    LOADER_ENTRY="$BLS_DIR/${MACHINE_ID}-0-rescue.conf"
+    LOADER_ENTRY="$BLS_DIR/${ENTRY_TOKEN}-0-rescue.conf"
     KERNEL="vmlinuz-0-rescue-${MACHINE_ID}"
     INITRD="initramfs-0-rescue-${MACHINE_ID}.img"
 fi
@@ -150,8 +158,8 @@ case "$COMMAND" in
                 echo "initrd     $BOOT_DIR/initrd"
             } > "$LOADER_ENTRY"
         else
-            if [[ -e "${BLS_DIR}/${MACHINE_ID}-${KERNEL_VERSION}.conf" ]]; then
-                cp -aT "${BLS_DIR}/${MACHINE_ID}-${KERNEL_VERSION}.conf" "$LOADER_ENTRY"
+            if [[ -e "${BLS_DIR}/${ENTRY_TOKEN}-${KERNEL_VERSION}.conf" ]]; then
+                cp -aT "${BLS_DIR}/${ENTRY_TOKEN}-${KERNEL_VERSION}.conf" "$LOADER_ENTRY"
             else
                 cp -aT "${KERNEL_IMAGE%/*}/bls.conf" "$LOADER_ENTRY"
             fi

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -29,6 +29,13 @@ test_run() {
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
     check_qemu_log
+
+    # rescue boot with custom entry token
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
+        -initrd "$BOOT_ROOT/custom-entry-token"/0-rescue/initrd
+    check_qemu_log
 }
 
 test_setup() {
@@ -60,6 +67,15 @@ test_setup() {
     kernel-install add "$KVERSION" "$KIMAGE"
     if [[ ! -e "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd ]]; then
         echo "Error: kernel-install failed to create $BOOT_ROOT/$TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
+
+    # test with a custom entry token different from machine-id
+    CUSTOM_TOKEN="custom-entry-token"
+    mkdir -p "$BOOT_ROOT/$CUSTOM_TOKEN/$KVERSION" "$BOOT_ROOT/loader/entries" "$BOOT_ROOT/$CUSTOM_TOKEN/0-rescue"
+    kernel-install add --entry-token "literal:$CUSTOM_TOKEN" "$KVERSION" "$KIMAGE"
+    if [[ ! -e "$BOOT_ROOT/$CUSTOM_TOKEN/0-rescue/initrd" ]]; then
+        echo "Error: kernel-install failed to create rescue initrd with custom entry token at $BOOT_ROOT/$CUSTOM_TOKEN/0-rescue/initrd" >&2
         return 1
     fi
 }

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -29,6 +29,14 @@ test_run() {
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
     test_marker_check
+
+    # rescue boot with custom entry token
+    test_marker_reset
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
+        -initrd "$BOOT_ROOT/custom-entry-token"/0-rescue/initrd
+    test_marker_check
 }
 
 test_setup() {
@@ -60,6 +68,20 @@ test_setup() {
     kernel-install add "$KVERSION" "$KIMAGE"
     if [[ ! -e "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd ]]; then
         echo "Error: kernel-install failed to create $BOOT_ROOT/$TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
+
+    # test with a custom entry token different from machine-id
+    CUSTOM_TOKEN="custom-entry-token"
+    mkdir -p "$BOOT_ROOT/$CUSTOM_TOKEN/$KVERSION" "$BOOT_ROOT/loader/entries" "$BOOT_ROOT/$CUSTOM_TOKEN/0-rescue"
+    kernel-install add --entry-token "literal:$CUSTOM_TOKEN" "$KVERSION" "$KIMAGE"
+    if [[ ! -e "$BOOT_ROOT/$CUSTOM_TOKEN/0-rescue/initrd" ]]; then
+        echo "Error: kernel-install failed to create rescue initrd with custom entry token at $BOOT_ROOT/$CUSTOM_TOKEN/0-rescue/initrd" >&2
+        return 1
+    fi
+    # the loader entry must use the entry token, not the machine-id
+    if [[ ! -e "$BOOT_ROOT/loader/entries/$CUSTOM_TOKEN-0-rescue.conf" ]]; then
+        echo "Error: rescue loader entry not created at entry-token path $BOOT_ROOT/loader/entries/$CUSTOM_TOKEN-0-rescue.conf" >&2
         return 1
     fi
 }


### PR DESCRIPTION
`51-dracut-rescue.install` hardcodes `$MACHINE_ID` for boot directory and loader entry paths. When `kernel-install` is configured with a non-machine-id entry token (e.g. via `bootctl --entry-token=os-id`), the paths diverge from the actual boot directory layout, breaking rescue image creation.

Use `$KERNEL_INSTALL_ENTRY_TOKEN` (exported by `kernel-install` since systemd 253) with a fallback to `$MACHINE_ID` for path construction. Rescue image filenames and BLS content fields keep using `$MACHINE_ID` as an identifier.

Fixes: https://github.com/dracut-ng/dracut/issues/2443

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it