### PR TITLE
fix(dracut): use entry token instead of machine-id for output path detection

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1225,7 +1225,7 @@ if ! [[ $outfile ]]; then
             MACHINE_ID="Default"
         fi
 
-        if [[ -n "${KERNEL_INSTALL_ENTRY_TOKEN-}" ]]; then
+        if [[ -n ${KERNEL_INSTALL_ENTRY_TOKEN-} ]]; then
             ENTRY_TOKEN="$KERNEL_INSTALL_ENTRY_TOKEN"
         elif [[ -f "${dracutsysrootdir-}"/etc/kernel/entry-token ]]; then
             read -r ENTRY_TOKEN < "${dracutsysrootdir-}"/etc/kernel/entry-token

--- a/dracut.sh
+++ b/dracut.sh
@@ -283,7 +283,7 @@ Creates initial ramdisk images for preloading modules
   --no-uefi             Disables UEFI mode.
   --no-ukify            Disables ukify.
   --no-machineid        Affects the default output filename of the UEFI
-                         executable, discarding the <MACHINE_ID> part.
+                         executable, discarding the <ENTRY_TOKEN> part.
   --uefi-stub [FILE]    Use the UEFI stub [FILE] to create an UEFI executable.
   --uefi-splash-image [FILE]
                         Use [FILE] as a splash image when creating an UEFI
@@ -1224,6 +1224,14 @@ if ! [[ $outfile ]]; then
         else
             MACHINE_ID="Default"
         fi
+
+        if [[ -n "${KERNEL_INSTALL_ENTRY_TOKEN-}" ]]; then
+            ENTRY_TOKEN="$KERNEL_INSTALL_ENTRY_TOKEN"
+        elif [[ -f "${dracutsysrootdir-}"/etc/kernel/entry-token ]]; then
+            read -r ENTRY_TOKEN < "${dracutsysrootdir-}"/etc/kernel/entry-token
+        else
+            ENTRY_TOKEN="$MACHINE_ID"
+        fi
     fi
 
     if [[ $uefi == "yes" ]]; then
@@ -1257,23 +1265,23 @@ if ! [[ $outfile ]]; then
             fi
         fi
         mkdir -p "${dracutsysrootdir-}$efidir/Linux"
-        outfile="${dracutsysrootdir-}$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
+        outfile="${dracutsysrootdir-}$efidir/Linux/linux-$kernel${ENTRY_TOKEN:+-${ENTRY_TOKEN}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
         if ! [[ $initrdname ]]; then
             initrdname="initramfs-${kernel}.img"
         fi
         if [[ -d "${dracutsysrootdir-}"/efi/loader/entries || -L "${dracutsysrootdir-}"/efi/loader/entries ]] \
-            && [[ $MACHINE_ID ]] \
-            && [[ -d "${dracutsysrootdir-}"/efi/${MACHINE_ID} || -L "${dracutsysrootdir-}"/efi/${MACHINE_ID} ]]; then
-            outfile="${dracutsysrootdir-}/efi/${MACHINE_ID}/${kernel}/initrd"
+            && [[ $ENTRY_TOKEN ]] \
+            && [[ -d "${dracutsysrootdir-}"/efi/${ENTRY_TOKEN} || -L "${dracutsysrootdir-}"/efi/${ENTRY_TOKEN} ]]; then
+            outfile="${dracutsysrootdir-}/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -d "${dracutsysrootdir-}"/boot/loader/entries || -L "${dracutsysrootdir-}"/boot/loader/entries ]] \
-            && [[ $MACHINE_ID ]] \
-            && [[ -d "${dracutsysrootdir-}"/boot/${MACHINE_ID} || -L "${dracutsysrootdir-}"/boot/${MACHINE_ID} ]]; then
-            outfile="${dracutsysrootdir-}/boot/${MACHINE_ID}/${kernel}/initrd"
+            && [[ $ENTRY_TOKEN ]] \
+            && [[ -d "${dracutsysrootdir-}"/boot/${ENTRY_TOKEN} || -L "${dracutsysrootdir-}"/boot/${ENTRY_TOKEN} ]]; then
+            outfile="${dracutsysrootdir-}/boot/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -d "${dracutsysrootdir-}"/boot/efi/loader/entries || -L "${dracutsysrootdir-}"/boot/efi/loader/entries ]] \
-            && [[ $MACHINE_ID ]] \
-            && [[ -d "${dracutsysrootdir-}"/boot/efi/${MACHINE_ID} || -L "${dracutsysrootdir-}"/boot/efi/${MACHINE_ID} ]]; then
-            outfile="${dracutsysrootdir-}/boot/efi/${MACHINE_ID}/${kernel}/initrd"
+            && [[ $ENTRY_TOKEN ]] \
+            && [[ -d "${dracutsysrootdir-}"/boot/efi/${ENTRY_TOKEN} || -L "${dracutsysrootdir-}"/boot/efi/${ENTRY_TOKEN} ]]; then
+            outfile="${dracutsysrootdir-}/boot/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -f "${dracutsysrootdir-}"/lib/modules/${kernel}/initrd ]]; then
             outfile="${dracutsysrootdir-}/lib/modules/${kernel}/initrd"
         elif [[ -e ${dracutsysrootdir-}/boot/vmlinuz-${kernel} ||
@@ -1281,13 +1289,13 @@ if ! [[ $outfile ]]; then
             -e ${dracutsysrootdir-}/boot/kernel-${kernel} ]]; then
             outfile="${dracutsysrootdir-}/boot/$initrdname"
         elif [[ -z ${dracutsysrootdir-} ]] \
-            && [[ $MACHINE_ID ]] \
+            && [[ $ENTRY_TOKEN ]] \
             && mountpoint -q /efi; then
-            outfile="/efi/${MACHINE_ID}/${kernel}/initrd"
+            outfile="/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -z ${dracutsysrootdir-} ]] \
-            && [[ $MACHINE_ID ]] \
+            && [[ $ENTRY_TOKEN ]] \
             && mountpoint -q /boot/efi; then
-            outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
+            outfile="/boot/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         else
             outfile="${dracutsysrootdir-}/boot/$initrdname"
         fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -289,7 +289,7 @@ Creates initial ramdisk images for preloading modules
   --no-uefi             Disables UEFI mode.
   --no-ukify            Disables ukify.
   --no-machineid        Affects the default output filename of the UEFI
-                         executable, discarding the <MACHINE_ID> part.
+                         executable, discarding the <ENTRY_TOKEN> part.
   --uefi-stub [FILE]    Use the UEFI stub [FILE] to create an UEFI executable.
   --uefi-splash-image [FILE]
                         Use [FILE] as a splash image when creating an UEFI
@@ -1245,6 +1245,14 @@ if ! [[ $outfile ]]; then
         else
             MACHINE_ID="Default"
         fi
+
+        if [[ -n "${KERNEL_INSTALL_ENTRY_TOKEN-}" ]]; then
+            ENTRY_TOKEN="$KERNEL_INSTALL_ENTRY_TOKEN"
+        elif [[ -f "${dracutsysrootdir-}"/etc/kernel/entry-token ]]; then
+            read -r ENTRY_TOKEN < "${dracutsysrootdir-}"/etc/kernel/entry-token
+        else
+            ENTRY_TOKEN="$MACHINE_ID"
+        fi
     fi
 
     if [[ $uefi == "yes" ]]; then
@@ -1278,23 +1286,23 @@ if ! [[ $outfile ]]; then
             fi
         fi
         mkdir -p "${dracutsysrootdir-}$efidir/Linux"
-        outfile="${dracutsysrootdir-}$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
+        outfile="${dracutsysrootdir-}$efidir/Linux/linux-$kernel${ENTRY_TOKEN:+-${ENTRY_TOKEN}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
         if ! [[ $initrdname ]]; then
             initrdname="initramfs-${kernel}.img"
         fi
         if [[ -d "${dracutsysrootdir-}"/efi/loader/entries || -L "${dracutsysrootdir-}"/efi/loader/entries ]] \
-            && [[ $MACHINE_ID ]] \
-            && [[ -d "${dracutsysrootdir-}"/efi/${MACHINE_ID} || -L "${dracutsysrootdir-}"/efi/${MACHINE_ID} ]]; then
-            outfile="${dracutsysrootdir-}/efi/${MACHINE_ID}/${kernel}/initrd"
+            && [[ $ENTRY_TOKEN ]] \
+            && [[ -d "${dracutsysrootdir-}"/efi/${ENTRY_TOKEN} || -L "${dracutsysrootdir-}"/efi/${ENTRY_TOKEN} ]]; then
+            outfile="${dracutsysrootdir-}/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -d "${dracutsysrootdir-}"/boot/loader/entries || -L "${dracutsysrootdir-}"/boot/loader/entries ]] \
-            && [[ $MACHINE_ID ]] \
-            && [[ -d "${dracutsysrootdir-}"/boot/${MACHINE_ID} || -L "${dracutsysrootdir-}"/boot/${MACHINE_ID} ]]; then
-            outfile="${dracutsysrootdir-}/boot/${MACHINE_ID}/${kernel}/initrd"
+            && [[ $ENTRY_TOKEN ]] \
+            && [[ -d "${dracutsysrootdir-}"/boot/${ENTRY_TOKEN} || -L "${dracutsysrootdir-}"/boot/${ENTRY_TOKEN} ]]; then
+            outfile="${dracutsysrootdir-}/boot/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -d "${dracutsysrootdir-}"/boot/efi/loader/entries || -L "${dracutsysrootdir-}"/boot/efi/loader/entries ]] \
-            && [[ $MACHINE_ID ]] \
-            && [[ -d "${dracutsysrootdir-}"/boot/efi/${MACHINE_ID} || -L "${dracutsysrootdir-}"/boot/efi/${MACHINE_ID} ]]; then
-            outfile="${dracutsysrootdir-}/boot/efi/${MACHINE_ID}/${kernel}/initrd"
+            && [[ $ENTRY_TOKEN ]] \
+            && [[ -d "${dracutsysrootdir-}"/boot/efi/${ENTRY_TOKEN} || -L "${dracutsysrootdir-}"/boot/efi/${ENTRY_TOKEN} ]]; then
+            outfile="${dracutsysrootdir-}/boot/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -f "${dracutsysrootdir-}"/lib/modules/${kernel}/initrd ]]; then
             outfile="${dracutsysrootdir-}/lib/modules/${kernel}/initrd"
         elif [[ -e ${dracutsysrootdir-}/boot/vmlinuz-${kernel} ||
@@ -1302,13 +1310,13 @@ if ! [[ $outfile ]]; then
             -e ${dracutsysrootdir-}/boot/kernel-${kernel} ]]; then
             outfile="${dracutsysrootdir-}/boot/$initrdname"
         elif [[ -z ${dracutsysrootdir-} ]] \
-            && [[ $MACHINE_ID ]] \
+            && [[ $ENTRY_TOKEN ]] \
             && mountpoint -q /efi; then
-            outfile="/efi/${MACHINE_ID}/${kernel}/initrd"
+            outfile="/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         elif [[ -z ${dracutsysrootdir-} ]] \
-            && [[ $MACHINE_ID ]] \
+            && [[ $ENTRY_TOKEN ]] \
             && mountpoint -q /boot/efi; then
-            outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
+            outfile="/boot/efi/${ENTRY_TOKEN}/${kernel}/initrd"
         else
             outfile="${dracutsysrootdir-}/boot/$initrdname"
         fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -1246,7 +1246,7 @@ if ! [[ $outfile ]]; then
             MACHINE_ID="Default"
         fi
 
-        if [[ -n "${KERNEL_INSTALL_ENTRY_TOKEN-}" ]]; then
+        if [[ -n ${KERNEL_INSTALL_ENTRY_TOKEN-} ]]; then
             ENTRY_TOKEN="$KERNEL_INSTALL_ENTRY_TOKEN"
         elif [[ -f "${dracutsysrootdir-}"/etc/kernel/entry-token ]]; then
             read -r ENTRY_TOKEN < "${dracutsysrootdir-}"/etc/kernel/entry-token

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -622,9 +622,11 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
 **--uefi**::
     Instead of creating an initramfs image, dracut will create an UEFI
     executable, which can be executed by an UEFI BIOS. The default output
-    filename is _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+    filename is _<EFI>/EFI/Linux/linux-$kernel$-<ENTRY_TOKEN>-<BUILD_ID>.efi_.
     <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
-    partition is mounted. The <BUILD_ID> is taken from BUILD_ID in
+    partition is mounted. The <ENTRY_TOKEN> is read from
+    `$KERNEL_INSTALL_ENTRY_TOKEN`, _/etc/kernel/entry-token_, or falls back to
+    the machine ID. The <BUILD_ID> is taken from BUILD_ID in
     _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
     if BUILD_ID is non-existent or empty.
 
@@ -639,7 +641,7 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
 
 **--no-machineid**::
     Affects the default output filename of **--uefi** and will discard the
-    <MACHINE_ID> part.
+    <ENTRY_TOKEN> part.
 
 **--uefi-stub** _<file>_::
     Specifies the UEFI stub loader, which will load the attached kernel,

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -648,9 +648,11 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
 **--uefi**::
     Instead of creating an initramfs image, dracut will create an UEFI
     executable, which can be executed by an UEFI BIOS. The default output
-    filename is _<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+    filename is _<EFI>/EFI/Linux/linux-$kernel$-<ENTRY_TOKEN>-<BUILD_ID>.efi_.
     <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
-    partition is mounted. The <BUILD_ID> is taken from BUILD_ID in
+    partition is mounted. The <ENTRY_TOKEN> is read from
+    `$KERNEL_INSTALL_ENTRY_TOKEN`, _/etc/kernel/entry-token_, or falls back to
+    the machine ID. The <BUILD_ID> is taken from BUILD_ID in
     _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
     if BUILD_ID is non-existent or empty.
 
@@ -665,7 +667,7 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
 
 **--no-machineid**::
     Affects the default output filename of **--uefi** and will discard the
-    <MACHINE_ID> part.
+    <ENTRY_TOKEN> part.
 
 **--uefi-stub** _<file>_::
     Specifies the UEFI stub loader, which will load the attached kernel,

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -334,15 +334,17 @@ Instead of creating an initramfs image, dracut will create an UEFI
 executable, which can be executed by an UEFI BIOS (default=no).
 +
 The default output filename is
-_<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+_<EFI>/EFI/Linux/linux-$kernel$-<ENTRY_TOKEN>-<BUILD_ID>.efi_.
 <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
-partition is mounted. The `<BUILD_ID>` is taken from `BUILD_ID` in
+partition is mounted. The `<ENTRY_TOKEN>` is read from
+`$KERNEL_INSTALL_ENTRY_TOKEN`, _/etc/kernel/entry-token_, or falls back to
+the machine ID. The `<BUILD_ID>` is taken from `BUILD_ID` in
 _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
 if `BUILD_ID` is non-existent or empty.
 
 *machine_id=*"__{yes|no}__"::
 Affects the default output filename of the UEFI executable, including the
-`<MACHINE_ID>` part (default=yes).
+`<ENTRY_TOKEN>` part (default=yes).
 
 *uefi_stub=*"_<file>_"::
 Specifies the UEFI stub loader, which will load the attached kernel,

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -338,15 +338,17 @@ Instead of creating an initramfs image, dracut will create an UEFI
 executable, which can be executed by an UEFI BIOS (default=no).
 +
 The default output filename is
-_<EFI>/EFI/Linux/linux-$kernel$-<MACHINE_ID>-<BUILD_ID>.efi_.
+_<EFI>/EFI/Linux/linux-$kernel$-<ENTRY_TOKEN>-<BUILD_ID>.efi_.
 <EFI> might be _/efi_, _/boot_ or _/boot/efi_ depending on where the ESP
-partition is mounted. The `<BUILD_ID>` is taken from `BUILD_ID` in
+partition is mounted. The `<ENTRY_TOKEN>` is read from
+`$KERNEL_INSTALL_ENTRY_TOKEN`, _/etc/kernel/entry-token_, or falls back to
+the machine ID. The `<BUILD_ID>` is taken from `BUILD_ID` in
 _/usr/lib/os-release_ or if it exists _/etc/os-release_ and is left out,
 if `BUILD_ID` is non-existent or empty.
 
 *machine_id=*"__{yes|no}__"::
 Affects the default output filename of the UEFI executable, including the
-`<MACHINE_ID>` part (default=yes).
+`<ENTRY_TOKEN>` part (default=yes).
 
 *uefi_stub=*"_<file>_"::
 Specifies the UEFI stub loader, which will load the attached kernel,

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -62,6 +62,26 @@ test_setup() {
         echo "Error: kernel-install failed to create $BOOT_ROOT/$TOKEN/$KVERSION/initrd" >&2
         return 1
     fi
+
+    # test dracut outfile path detection with a custom entry token
+    CUSTOM_TOKEN="custom-entry-token"
+    mkdir -p /boot/loader/entries "/boot/$CUSTOM_TOKEN/$KVERSION" /etc/kernel
+    echo "$CUSTOM_TOKEN" > /etc/kernel/entry-token
+    call_dracut --add-confdir test-root --kver "$KVERSION" -f
+    if [[ ! -e "/boot/$CUSTOM_TOKEN/$KVERSION/initrd" ]]; then
+        echo "Error: dracut failed to detect outfile path with custom entry token at /boot/$CUSTOM_TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
+
+    # test that KERNEL_INSTALL_ENTRY_TOKEN env var takes precedence over the file
+    ENV_TOKEN="env-entry-token"
+    mkdir -p "/boot/$ENV_TOKEN/$KVERSION"
+    KERNEL_INSTALL_ENTRY_TOKEN="$ENV_TOKEN" call_dracut --add-confdir test-root --kver "$KVERSION" -f
+    if [[ ! -e "/boot/$ENV_TOKEN/$KVERSION/initrd" ]]; then
+        echo "Error: dracut did not respect KERNEL_INSTALL_ENTRY_TOKEN env var, expected initrd at /boot/$ENV_TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
+    rm -f /etc/kernel/entry-token
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -62,6 +62,42 @@ test_setup() {
         echo "Error: kernel-install failed to create $BOOT_ROOT/$TOKEN/$KVERSION/initrd" >&2
         return 1
     fi
+
+    # test dracut outfile path detection with a custom entry token
+    CUSTOM_TOKEN="custom-entry-token"
+    mkdir -p /boot/loader/entries "/boot/$CUSTOM_TOKEN/$KVERSION" /etc/kernel
+    echo "$CUSTOM_TOKEN" > /etc/kernel/entry-token
+    call_dracut --add-confdir test-root --kver "$KVERSION" -f
+    if [[ ! -e "/boot/$CUSTOM_TOKEN/$KVERSION/initrd" ]]; then
+        echo "Error: dracut failed to detect outfile path with custom entry token at /boot/$CUSTOM_TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
+
+    # test that KERNEL_INSTALL_ENTRY_TOKEN env var takes precedence over the file
+    ENV_TOKEN="env-entry-token"
+    mkdir -p "/boot/$ENV_TOKEN/$KVERSION"
+    KERNEL_INSTALL_ENTRY_TOKEN="$ENV_TOKEN" call_dracut --add-confdir test-root --kver "$KVERSION" -f
+    if [[ ! -e "/boot/$ENV_TOKEN/$KVERSION/initrd" ]]; then
+        echo "Error: dracut did not respect KERNEL_INSTALL_ENTRY_TOKEN env var, expected initrd at /boot/$ENV_TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
+    rm -f /etc/kernel/entry-token
+
+    # test that the UKI output filename uses the entry token, not the machine-id
+    if command -v ukify &> /dev/null; then
+        echo "$CUSTOM_TOKEN" > /etc/kernel/entry-token
+        call_dracut --uefi --add-confdir test-root --kver "$KVERSION" -f
+        shopt -s nullglob
+        uki=(/boot/EFI/Linux/linux-"$KVERSION"-"$CUSTOM_TOKEN"*.efi
+            /boot/efi/EFI/Linux/linux-"$KVERSION"-"$CUSTOM_TOKEN"*.efi
+            /efi/EFI/Linux/linux-"$KVERSION"-"$CUSTOM_TOKEN"*.efi)
+        shopt -u nullglob
+        if [[ ${#uki[@]} -eq 0 ]]; then
+            echo "Error: dracut did not name the UKI using the entry token, expected .../EFI/Linux/linux-$KVERSION-$CUSTOM_TOKEN*.efi" >&2
+            return 1
+        fi
+        rm -f /etc/kernel/entry-token
+    fi
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
`dracut.sh` hardcodes `$MACHINE_ID` for output path detection when no explicit output file is given. When the system is configured with a non-machine-id entry token (e.g. via `bootctl --entry-token=os-id`), directory checks fail because the actual directories use the entry token, not the 32-char machine-id hex string.

Resolve the entry token from `$KERNEL_INSTALL_ENTRY_TOKEN`, `/etc/kernel/entry-token`, or fall back to `$MACHINE_ID`. Use it for all BLS directory lookups, mountpoint fallbacks, and the UKI output filename.

Same class of bug as #2443 / #2444, but in the core dracut command rather than the rescue install hook.

Fixes: https://github.com/dracut-ng/dracut/issues/2445

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it