### PR TITLE
fix(busybox): ensure /usr/bin/sh symlink is always created #2454

### DIFF
--- a/modules.d/81busybox/module-setup.sh
+++ b/modules.d/81busybox/module-setup.sh
@@ -35,4 +35,10 @@ install() {
 
         ln_r /usr/bin/busybox "$_path"
     done
+    # Ensure /usr/bin/sh is always available.
+    # POSIX mandates /bin/sh and most scripts use #!/bin/sh (-> /usr/bin/sh
+    # on merged-usr). find_binary may locate 'sh' at a non-standard path
+    # (e.g. /usr/sbin/sh) depending on $DRACUT_PATH ordering, so create
+    # the symlink explicitly if absent.
+    [[ -e "${_dstdir}/usr/bin/sh" ]] || ln_r /usr/bin/busybox /usr/bin/sh
 }


### PR DESCRIPTION
POSIX mandates that /bin/sh must exist. On merged-usr systems this resolves to /usr/bin/sh. The busybox module creates applet symlinks at whatever path find_binary() returns, which depends on the DRACUT_PATH ordering (default: /usr/sbin /sbin /usr/bin /bin).

On Fedora 42+, the busybox package (1.37.0+) places applet symlinks under /usr/sbin/ as part of the /usr/sbin → /usr/bin unification transition. Since DRACUT_PATH searches /usr/sbin first, find_binary("sh") returns /usr/sbin/sh and the module only creates that symlink — leaving /usr/bin/sh (and thus /bin/sh) absent.

This breaks any script using #!/bin/sh as its shebang — notably squash-lib's init-squash.sh which serves as PID 1 in the squash loader. The kernel fails with "Failed to execute /init (error -2)".

Fix this by unconditionally ensuring /usr/bin/sh exists after the applet symlink loop. If find_binary already placed sh at /usr/bin/sh, the check is a no-op.

This pull request ensures /usr/bin/sh symlink is always created by the busybox module, fixing kdump squashfs boot failure on Fedora 42/43 where busybox places sh at /usr/sbin/sh due to DRACUT_PATH ordering.

Fixes: https://github.com/dracut-ng/dracut/issues/2454

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it