### PR TITLE
Fixes for various dhcp-related issues

### DIFF
--- a/modules.d/11systemd-networkd/networkd-run.sh
+++ b/modules.d/11systemd-networkd/networkd-run.sh
@@ -12,10 +12,12 @@ for ifpath in /sys/class/net/*; do
         leases_file="/run/systemd/netif/leases/$(cat "$ifpath"/ifindex)"
         dhcpopts_file="/tmp/dhclient.${ifname}.dhcpopts"
         if [ -r "$leases_file" ]; then
-            grep -E "^(NEXT_SERVER|ROOT_PATH)=" "$leases_file" \
-                | sed -e "s/NEXT_SERVER=/new_next_server='/" \
-                    -e "s/ROOT_PATH=/new_root_path='/" \
-                    -e "s/$/'/" > "$dhcpopts_file" || :
+            while IFS='=' read -r key val; do
+                case "$key" in
+                    NEXT_SERVER) printf 'new_next_server=%q\n' "$val" ;;
+                    ROOT_PATH) printf 'new_root_path=%q\n' "$val" ;;
+                esac
+            done < "$leases_file" > "$dhcpopts_file"
         else
             # Since systemd v261 the DHCP lease is no longer serialized to /run/, use the new networkctl command.
             lease=$(networkctl --no-pager --no-legend --full dhcp-lease "$ifname" 2> /dev/null) || lease=""

--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -48,22 +48,24 @@ setup_interface() {
     if [ -n "$gw" ]; then
         if [ "$mask" = "255.255.255.255" ]; then
             # point-to-point connection => set explicit route to gateway
-            echo ip route add "$gw" dev "$netif" > /tmp/net."$netif".gw
+            printf 'ip route add %q dev %q\n' "$gw" "$netif" > /tmp/net."$netif".gw
         fi
 
         echo "$gw" | {
             IFS=' ' read -r main_gw other_gw
-            echo ip route replace default via "$main_gw" dev "$netif" >> /tmp/net."$netif".gw
+            printf 'ip route replace default via %q dev %q\n' "$main_gw" "$netif" >> /tmp/net."$netif".gw
             if [ -n "$other_gw" ]; then
                 for g in $other_gw; do
-                    echo ip route add default via "$g" dev "$netif" >> /tmp/net."$netif".gw
+                    printf 'ip route add default via %q dev %q\n' "$g" "$netif" >> /tmp/net."$netif".gw
                 done
             fi
         }
     fi
 
     if getargbool 1 rd.peerdns; then
-        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        if [ -n "${search}${domain}" ]; then
+            echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        fi
         if [ -n "$namesrv" ]; then
             for s in $namesrv; do
                 echo nameserver "$s"
@@ -72,7 +74,10 @@ setup_interface() {
     fi
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicitly add any domain if set.
-    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname%."$domain"}${domain:+.$domain}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 }
 
 setup_interface6() {
@@ -95,7 +100,9 @@ setup_interface6() {
         ${preferred_lft:+preferred_lft ${preferred_lft}}
 
     if getargbool 1 rd.peerdns; then
-        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        if [ -n "${search}${domain}" ]; then
+            echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        fi
         if [ -n "$namesrv" ]; then
             for s in $namesrv; do
                 echo nameserver "$s"
@@ -105,7 +112,10 @@ setup_interface6() {
 
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicitly add any domain if set.
-    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname%."$domain"}${domain:+.$domain}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 }
 
 parse_option_121() {

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -28,7 +28,7 @@ do_dhcp_parallel() {
     # event for nfsroot
     # XXX add -V vendor class and option parsing per kernel
 
-    [ -e "/tmp/dhclient.$netif.pid" ] && return 0
+    [ -e "/tmp/dhclient.${netif}.pid" ] && return 0
 
     if ! iface_has_carrier "$netif"; then
         warn "No carrier detected on interface $netif"
@@ -127,8 +127,10 @@ do_ipv6auto() {
     wait_for_ipv6_auto "$netif"
     ret=$?
 
-    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
-
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
     return "$ret"
 }
 
@@ -140,7 +142,10 @@ do_ipv6link() {
     echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
     linkup "$netif"
 
-    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 
     return "$ret"
 }
@@ -193,8 +198,12 @@ do_static() {
         ip addr add "$ip/$mask" ${srv:+peer "$srv"} brd + dev "$netif"
     fi
 
-    [ -n "$gw" ] && echo "ip route replace default via '$gw' dev '$netif'" > "/tmp/net.$netif.gw"
-    [ -n "$hostname" ] && echo "echo '$hostname' > /proc/sys/kernel/hostname" > "/tmp/net.$netif.hostname"
+    [ -n "$gw" ] && printf "ip route replace default via %q dev %q\n" "$gw" "$netif" > "/tmp/net.${netif}.gw"
+
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 
     return 0
 }
@@ -423,7 +432,7 @@ fi
 [ -n "$2" ] && [ "$2" = "-m" ] && [ -z "$netroot" ] && manualup="$2"
 
 if [ -n "$manualup" ]; then
-    : > "/tmp/net.$netif.manualup"
+    : > "/tmp/net.${netif}.manualup"
     rm -f "/tmp/net.${netif}.did-setup"
 else
     [ -e "/tmp/net.${netif}.did-setup" ] && exit 0
@@ -464,7 +473,7 @@ for p in $(getargs ip=); do
     # Store config for later use
     for i in ip srv gw mask hostname macaddr mtu dns1 dns2; do
         eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
-    done > "/tmp/net.$netif.override"
+    done > "/tmp/net.${netif}.override"
 
     for autoopt in $(str_replace "$autoconf" "," " "); do
         case $autoopt in
@@ -498,7 +507,7 @@ for p in $(getargs ip=); do
     # setup nameserver
     for s in "$dns1" "$dns2" $(getargs nameserver); do
         [ -n "$s" ] || continue
-        echo "nameserver $s" >> "/tmp/net.$netif.resolv.conf"
+        echo "nameserver $s" >> "/tmp/net.${netif}.resolv.conf"
     done
 
     if [ $ret -eq 0 ]; then
@@ -548,7 +557,7 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
 
     for s in $(getargs nameserver); do
         [ -n "$s" ] || continue
-        echo "nameserver $s" >> "/tmp/net.$netif.resolv.conf"
+        echo "nameserver $s" >> "/tmp/net.${netif}.resolv.conf"
     done
 
     if [ "$ret" -eq 0 ] && [ -n "$(ls "/tmp/leaseinfo.${netif}"* 2> /dev/null)" ]; then

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -131,8 +131,13 @@ setup_net() {
     [ -e "/tmp/net.ifaces" ] && read -r IFACES < /tmp/net.ifaces
     [ -z "$IFACES" ] && IFACES="$netif"
     # run the scripts written by ifup
-    # shellcheck disable=SC1090
-    [ -e /tmp/net."$netif".hostname ] && . /tmp/net."$netif".hostname
+    if [ -e /tmp/net."$netif".hostname ]; then
+        if grep -qE '[$`;&|(]' /tmp/net."$netif".hostname 2>/dev/null; then
+            warn "setup_net $netif: /tmp/net.$netif.hostname contains suspicious shell metacharacters"
+        fi
+        # shellcheck disable=SC1090
+        . /tmp/net."$netif".hostname
+    fi
     # shellcheck disable=SC1090
     [ -e /tmp/net."$netif".override ] && . /tmp/net."$netif".override
     # shellcheck disable=SC1090

--- a/modules.d/74iscsi/iscsiroot.sh
+++ b/modules.d/74iscsi/iscsiroot.sh
@@ -144,7 +144,7 @@ handle_netroot() {
 
     if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name ] && ! [ -f /tmp/iscsi_set_initiator ]; then
         iscsi_initiator=$(while read -r line || [ -n "$line" ]; do echo "$line"; done < /sys/firmware/ibft/initiator/initiator-name)
-        echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+        printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
@@ -165,7 +165,7 @@ handle_netroot() {
 
     if [ -z "$iscsi_initiator" ]; then
         iscsi_initiator=$(iscsi-iname)
-        echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+        printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
@@ -189,7 +189,7 @@ handle_netroot() {
         iscsi_lun=0
     fi
 
-    echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+    printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
     ln -fs /run/initiatorname.iscsi /dev/.initiatorname.iscsi
     if ! [ -e /etc/iscsi/initiatorname.iscsi ]; then
         mkdir -p /etc/iscsi
@@ -210,14 +210,14 @@ handle_netroot() {
 
     if [ "$root" = "dhcp" ] || [ "$netroot" = "dhcp" ]; then
         # if root is not specified try to mount the whole iSCSI LUN
-        printf 'SYMLINK=="disk/by-path/*-iscsi-*-%s", SYMLINK+="root"\n' "$iscsi_lun" >> /etc/udev/rules.d/99-iscsi-root.rules
+        printf 'SYMLINK=="disk/by-path/*-iscsi-*-%s", SYMLINK+="root"\n' "$(printf '%s' "$iscsi_lun" | tr -d '"')" >> /etc/udev/rules.d/99-iscsi-root.rules
         udevadm control --reload
         write_fs_tab /dev/root
         wait_for_dev -n /dev/root
 
         # install mount script
         [ -z "${DRACUT_SYSTEMD-}" ] \
-            && echo "iscsi_lun=$iscsi_lun . /bin/mount-lun.sh " > "$hookdir"/mount/01-$$-iscsi.sh
+            && printf 'iscsi_lun=%q . /bin/mount-lun.sh\n' "$iscsi_lun" > "$hookdir"/mount/01-$$-iscsi.sh
     fi
 
     if strglobin "$iscsi_target_ip" '*:*:*' && ! strglobin "$iscsi_target_ip" '['; then

--- a/modules.d/74iscsi/parse-iscsiroot.sh
+++ b/modules.d/74iscsi/parse-iscsiroot.sh
@@ -111,7 +111,7 @@ fi
 
 if arg=$(getarg rd.iscsi.initiator -d iscsi_initiator=) && [ -n "$arg" ] && ! [ -f /run/initiatorname.iscsi ]; then
     iscsi_initiator=$arg
-    echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+    printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
     ln -fs /run/initiatorname.iscsi /dev/.initiatorname.iscsi
     rm -f /etc/iscsi/initiatorname.iscsi
     mkdir -p /etc/iscsi
@@ -127,7 +127,7 @@ fi
 if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name ] && ! [ -f /tmp/iscsi_set_initiator ]; then
     iscsi_initiator=$(while read -r line || [ -n "$line" ]; do echo "$line"; done < /sys/firmware/ibft/initiator/initiator-name)
     if [ -n "$iscsi_initiator" ]; then
-        echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+        printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi

--- a/modules.d/74iscsi/parse-iscsiroot.sh
+++ b/modules.d/74iscsi/parse-iscsiroot.sh
@@ -89,7 +89,7 @@ if [ -n "$iscsi_firmware" ]; then
     echo "${DRACUT_SYSTEMD+systemctl is-active initrd-root-device.target || }[ -f '/tmp/iscsistarted-firmware' ]" > "$hookdir"/initqueue/finished/iscsi_started.sh
     /sbin/initqueue --unique --online /sbin/iscsiroot online "iscsi:" "$NEWROOT"
     /sbin/initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "iscsi:" "$NEWROOT"
-    /sbin/initqueue --unique --onetime --settled /sbin/iscsiroot online "iscsi:" "'$NEWROOT'"
+    /sbin/initqueue --unique --onetime --settled /sbin/iscsiroot online "iscsi:" "$NEWROOT"
 fi
 
 # ISCSI actually supported?
@@ -105,7 +105,7 @@ modprobe -b -q be2iscsi
 
 if [ -n "$netroot" ] && [ "$root" != "/dev/root" ] && [ "$root" != "dhcp" ]; then
     if ! getargbool 1 rd.neednet > /dev/null || ! getarg "ip="; then
-        /sbin/initqueue --unique --onetime --settled /sbin/iscsiroot dummy "'$netroot'" "'$NEWROOT'"
+        /sbin/initqueue --unique --onetime --settled /sbin/iscsiroot dummy "$netroot" "$NEWROOT"
     fi
 fi
 

--- a/modules.d/77initqueue/initqueue.sh
+++ b/modules.d/77initqueue/initqueue.sh
@@ -64,7 +64,8 @@ fi
     # shellcheck disable=SC2016
     [ -n "$onetime" ] && echo '[ -e "$job" ] && rm -f -- "$job"'
     [ -n "$env" ] && echo "$env"
-    echo "$exe" "$@"
+    printf '%q ' "$exe" "$@"
+    printf '\n'
 } > "/tmp/$$-${job}.sh"
 
 mv -f "/tmp/$$-${job}.sh" "$hookdir/initqueue${qname}/${job}.sh"


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2026-6893

and similar discovered issues.

If POSIX / dash compatibility is to be preserved, `printf %q` needs to be replaced -- but since it's used in `modules.d/35network-manager/nm-run.sh` already, I decided to keep it this way, until some project-wide decision is made. 

I created only one single PR for simplicity; I can split it into multiple MRs if desired.

I've removed `network-legacy`, since it has very little use at this point, but if we want to preserve it, I already have the patches for it.

Please let me know what you think.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
