### PR TITLE
fix(dracut): default to hostonly_cmdline=no in chroot

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1371,6 +1371,14 @@ check_kernel_compress_support() {
     return $?
 }
 
+# Returns 0 if the process runs in a chroot. Otherwise returns 1.
+# Return 2 in case /proc is not mounted or /proc/1/root cannot be accessed.
+is_chroot() {
+    local pid1root_stat
+    pid1root_stat=$(stat -Lc "%d/%i" /proc/1/root 2> /dev/null) || return 2
+    [ "$(stat -c "%d/%i" /)" != "$pid1root_stat" ]
+}
+
 # hostonly shell variable defaults to "-h" if not specified
 if [[ ${hostonly-} == "no" ]]; then
     unset hostonly
@@ -1387,8 +1395,8 @@ if [[ ${hostonly-} ]]; then
     fi
 fi
 
-if [[ ${hostonly-} ]] && ! [[ $hostonly_cmdline ]]; then
-    # Enable hostonly-cmdline by default in hostonly mode
+if [[ ${hostonly-} ]] && ! [[ $hostonly_cmdline ]] && ! is_chroot; then
+    # Enable hostonly-cmdline by default in hostonly mode (unless in chroot)
     hostonly_cmdline="yes"
 fi
 

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -196,9 +196,9 @@ WARNING: If chrooted to another root other than the real root device, use
 `--fstab` and provide a valid _/etc/fstab_.
 
 *hostonly_cmdline=*"__{yes|no}__"::
-If set to "yes", store the kernel command line arguments needed in the
-initramfs. If **hostonly="yes"** and this option is not configured, it's
-automatically set to "yes". (default=no)
+Store host-specific kernel command-line arguments in the initramfs when
+set to "yes". If left unset, it automatically enables when **hostonly="yes"**
+(unless running inside a chroot). (default=unset)
 
 *hostonly_nics+=*" [__<nic>__[ __<nic>__ ...]] "::
 Only enable listed NICs in the initramfs. The list can be empty, so other


### PR DESCRIPTION
autopkgtest-build-qemu builds an image that should include a initrd that can boot this image. It uses the `chroot` command to build the image. Relevant log:

```
$ sudo autopkgtest-build-qemu --boot=efi unstable /tmp/unstable-amd64.img
[...]
Exec: ['chroot', '/tmp/tmpyajn1s9p', 'eatmydata', 'apt-get', '-y', '--no-show-progress', '', 'install', 'linux-image-amd64']
[...]
Processing triggers for dracut (110-9) ...
update-initramfs: Generating /boot/initrd.img-6.19.11+deb14-amd64
dracut[W]: Turning off host-only mode: /dev is not mounted!
[...]
Exec: ['mount', '--bind', '/dev', '/tmp/tmpyajn1s9p/dev']
Exec: ['mount', '--bind', '/sys', '/tmp/tmpyajn1s9p/sys']
Exec: ['mount', '--bind', '/proc', '/tmp/tmpyajn1s9p/proc']
Exec: ['parted', '-s', '/dev/loop15', 'set', '1', 'esp', 'on']
Exec: ['chroot', '/tmp/tmpyajn1s9p', 'apt-get', 'update']
Hit:1 http://deb.debian.org/debian unstable InRelease
Reading package lists...
Exec: ['chroot', '/tmp/tmpyajn1s9p', 'apt-get', '-y', '--no-show-progress', 'install', 'grub-efi-amd64']
[...]
Processing triggers for dracut (110-9) ...
update-initramfs: Generating /boot/initrd.img-6.19.11+deb14-amd64
[...]
```

Converting the resulting image to raw, mounting it and running `lsinitrd` on `/boot/initrd.img-6.19.11+deb14-amd64` shows:

```
dracut cmdline:
 root=/dev/mapper/loop15p2 rootfstype=ext4 rootflags=rw,relatime
```

This boot hangs then at:

> (1 of 2) Job dev-mapper-loop0p1.device/start running (3s / no limit)
> (2 of 2) Job dracut-initqueue.service/start running (8s / no limit)

When installing `linux-image-amd64`, `/dev` is not mounted and dracut turns off host-only mode. That's what we want for this image. But then `/dev` gets mounted and the initrd is regenerated (when installing `grub-efi-amd64`). This time the initrd is build in host-only mode and hostonly-cmdline is enabled.

So default to `hostonly_cmdline=no` in case a chroot is detected. Users that want to use hostonly-cmdline in a chroot can specify `hostonly_cmdline=yes` in the dracut config or call dracut with `--hostonly-cmdline`.

Fixes: https://github.com/dracut-ng/dracut/issues/2355
Bug-Debian: https://bugs.debian.org/1132794

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
