### PR TITLE
fix(mdraid): install 59-persistent-storage-md.rules only when needed

### DIFF
--- a/modules.d/70mdraid/module-setup.sh
+++ b/modules.d/70mdraid/module-setup.sh
@@ -89,7 +89,11 @@ install() {
 
     inst_rules "$moddir/65-md-incremental-imsm.rules"
 
-    inst_rules "$moddir/59-persistent-storage-md.rules"
+    # Install our 59-persistent-storage-md.rules for mdadm < 4.5
+    # to extend 63-md-raid-arrays.rules with OPTIONS+="db_persist"
+    if ! grep -q db_persist "${initdir}${udevdir}/rules.d/63-md-raid-arrays.rules" 2> /dev/null; then
+        inst_rules "$moddir/59-persistent-storage-md.rules"
+    fi
 
     if [[ $hostonly ]] || [[ $mdadmconf == "yes" ]]; then
         if [[ -f "${dracutsysrootdir-}/etc/mdadm.conf" ]]; then


### PR DESCRIPTION
Dracut installs in the initrd a custom `59-persistent-storage-md.rules` only to set the option `db_persist`. The main purpose is that if an MD device is activated in the initrd, its properties are kept on the udev database after the transition from the initrd to the rootfs. This was added to fix detection issues when LVM is on top.

mdadm 4.5 included this change from Dracut. Therefore installing `59-persistent-storage-md.rules` is not needed any more when using mdadm >= 4.5. `59-persistent-storage-md.rules` can be removed completely once Dracut drops support for mdadm < 4.5.

See also: https://github.com/md-raid-utilities/mdadm/pull/143

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
