### PR TITLE
fix(hwdb): always install this module

### DIFF
--- a/modules.d/74hwdb/module-setup.sh
+++ b/modules.d/74hwdb/module-setup.sh
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 check() {
-    if [[ $hostonly ]]; then
+    if [[ $hostonly_mode == "strict" ]]; then
+        dwarn "hwdb: module not automatically included in strict hostonly" \
+            "mode, udev rules that use the built-in hwdb program will fail."
         return 255
     fi
 


### PR DESCRIPTION
This module is not being installed in hostonly mode, which causes udev rules that use the built-in hwdb program to fail.

This way, there won't be any surprises with udev rules not working, and it can be manually omitted if someone wants to save space.

Fixes #2534

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
