### PR TITLE
feat(systemd-journald): remove libgcrypt from add_dlopen_features

### DIFF
--- a/modules.d/11systemd-journald/module-setup.sh
+++ b/modules.d/11systemd-journald/module-setup.sh
@@ -28,7 +28,7 @@ depends() {
 
 # Config adjustments before installing anything.
 config() {
-    add_dlopen_features+=" libsystemd-shared-*.so:gcrypt,lz4,lzma,zstd "
+    add_dlopen_features+=" libsystemd-shared-*.so:lz4,lzma,zstd "
 }
 
 # Install the required file(s) and directories for the module in the initramfs.


### PR DESCRIPTION
0406aa64a788c63a0bb2fd9d60a2d3d2d96320cb only removed the fallback if dlopen notes are not being parsed. Moreover, libgcrypt survives only in unit tests after https://github.com/systemd/systemd/pull/42695.

Follow-up for 0406aa64a788c63a0bb2fd9d60a2d3d2d96320cb

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
