### PR TITLE
fix(rngd): add configuration file on ArchLinux

### DIFF
--- a/modules.d/16rngd/module-setup.sh
+++ b/modules.d/16rngd/module-setup.sh
@@ -37,6 +37,8 @@ install() {
 
     if [ -r /etc/sysconfig/rngd ]; then
         inst_simple "${moddir}/sysconfig" "/etc/sysconfig/rngd"
+    elif [ -r /etc/conf.d/rngd ]; then
+        inst_simple "${moddir}/conf.d" "/etc/conf.d/rngd"
     fi
 
     # make sure dependent libs are installed too


### PR DESCRIPTION
ArchLinux uses /etc/conf.d rather than /etc/sysconfig in its rngd.service to read environment variables from. So far this file was not included automatically, and only sysconfig was considered, leading to rngd.service failing on boot on ArchLinux if rng-tools is just installed. This commit adds the same handling for /etc/conf.d

Fixes: #2542

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
