### PR TITLE
ci(debian): order packages alphabetically

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -55,9 +55,9 @@ RUN case $(dpkg --print-architecture) in \
     gcc \
     gpg \
     gpg-agent \
+    iproute2 \
     iputils-arping \
     iputils-ping \
-    iproute2 \
     ipxe-qemu \
     isc-dhcp-server \
     iscsiuio \


### PR DESCRIPTION
iproute2 package should be order earlier to maintain alphabetical ordering.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
