### PR TITLE
ci(debian): remove unused variable

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -29,7 +29,6 @@ RUN case $(dpkg --print-architecture) in \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Dpkg::Use-Pty=0 \
     $arch_pkgs \
     $cpio \
-    $coreutils \
     $systemd_pkgs \
     asciidoctor \
     bluez \


### PR DESCRIPTION
coreutils variable is no longer used.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
