### PR TITLE
test(SYSTEMD): do not use test with globbing

### DIFF
--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -46,7 +46,7 @@ test_setup() {
 
     # shellcheck disable=SC2144 # We're not installing multilib libfido2, so
     # glob will only match once. More matches would break the test anyway.
-    if is_systemd_version_greater_or_equal 257 && [ -e /usr/lib*/libfido2.so.1 ] \
+    if is_systemd_version_greater_or_equal 257 && compgen -G /usr/lib*/libfido2.so.1 > /dev/null \
         && ! lsinitrd "$TESTDIR"/initramfs.testing | grep -E ' usr/lib[^/]*/libfido2\.so\.1\b' > /dev/null; then
         echo "Error: libfido2.so.1 should have been included in the initramfs" >&2
         return 1


### PR DESCRIPTION
There might be multiple files matching the globbing as it can be seen on `arch:latest`:

```
./test.sh: line 49: [: /usr/lib/libfido2.so.1: binary operator expected
```

Use `compgen` to check if the glob pattern matches one or more files without failing on multiple matches.

Follow-up for 48e4665c97b3c71f485b95426e5bf00dae3ab1ab

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
