### PR TITLE
fix(net-lib): validate iSCSI port parameters

### DIFF
--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -367,19 +367,14 @@ normalized_iscsi_name() {
     printf "%s" "$1" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9.:-'
 }
 
-_validate_iscsi_lun() {
-    local raw_lun="$1"
-
-    case "$raw_lun" in
-        *[!0-9]*)
-            warn "Given iSCSI LUN '$raw_lun' contains non-digits. Stripping non-digit characters."
-            printf "%s" "$raw_lun" | tr -cd '[:digit:]'
-            ;;
-        *)
-            # Purely decimal digits
-            echo "$raw_lun"
-            ;;
-    esac
+strip_non_digits() {
+    local str="$1"
+    local msg="$2"
+    if [ -n "$str" ] && ! isdigit "$str"; then
+        warn "${msg:+$msg }'$str' contains non-digits. Stripping non-digit characters."
+        str="$(printf "%s" "$str" | tr -cd '[:digit:]')"
+    fi
+    printf "%s" "$str"
 }
 
 parse_iscsi_root() {
@@ -465,7 +460,7 @@ parse_iscsi_root() {
             iscsi_netdev_name=$1
             shift
         fi
-        iscsi_lun=$(_validate_iscsi_lun "$1")
+        iscsi_lun=$(strip_non_digits "$1" "iSCSI LUN")
         shift
         if [ $# -ne 0 ]; then
             warn "Invalid parameter in iscsi: parameter!"
@@ -483,7 +478,7 @@ parse_iscsi_root() {
         fi
     fi
 
-    iscsi_lun=$(_validate_iscsi_lun "$1")
+    iscsi_lun=$(strip_non_digits "$1" "iSCSI LUN")
     shift
 
     iscsi_target_name=$(printf "%s:" "$@")

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -448,7 +448,7 @@ parse_iscsi_root() {
     [ $# -ge 2 ] || return 0
     iscsi_protocol=$1
     shift # ignored
-    iscsi_target_port=$1
+    iscsi_target_port=$(strip_non_digits "$1" "iSCSI port")
     shift
 
     if [ -n "$iscsi_target_name" ]; then

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -3,6 +3,8 @@
 # shellcheck disable=SC2034
 IFNETFILE="/tmp/bootnetif"
 
+command -v getarg > /dev/null || . /lib/dracut-lib.sh
+
 is_ip() {
     echo "$1" | {
         IFS=. read -r a b c d


### PR DESCRIPTION
Similar to 05c02db994ca322371a40695a3cc223faa1c7258, the iSCSI port is a number.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
