### PR TITLE
fix(base): usable_root() not working as intended

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -723,8 +723,12 @@ usable_root() {
 
     [ -d "$1" ] || return 1
 
-    for _i in "$1"/usr/lib*/ld-*.so "$1"/lib*/ld-*.so; do
+    for _i in "$1"/usr/lib*/ld-*.so* "$1"/lib*/ld-*.so*; do
         [ -e "$_i" ] && return 0
+    done
+
+    for _i in proc sys dev; do
+        [ -e "$1"/$_i ] || return 1
     done
 
     return 0


### PR DESCRIPTION
Since commit ff370f5517ee860d51f4f27089f99a738b0ba5a1, the only check that can return false in the `usable_root()` function is that the first argument (usually `$NEWROOT`) is a directory, so it should have changed the final return value to false.

But, there is a problem with doing that: the check for the dynamic loader is broken, because glibc has been naming the loader `ld-linux-<platform>.so.<abi>` for a long time.

Also, there is another problem: after fixing both issues, `usable_root()` will always return false if the root filesystem is holding only statically linked binaries.

So, we need to fix two things in this function:
- Expand the glob to actually check the current pattern of the dynamic loader.
- Bring back the /proc, /sys/, /dev checks.

Fixes ff370f5517ee860d51f4f27089f99a738b0ba5a1

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
