### PR TITLE
fix(dracut-systemd): actually make rd.break=pre-trigger stop before pre-trigger

### DIFF
--- a/modules.d/77dracut-systemd/dracut-pre-trigger.sh
+++ b/modules.d/77dracut-systemd/dracut-pre-trigger.sh
@@ -10,9 +10,8 @@ source_conf /etc/conf.d
 
 make_trace_mem "hook pre-trigger" '1:shortmem' '2+:mem' '3+:slab'
 
-source_hook pre-trigger
-
 getargs 'rd.break=pre-trigger' && emergency_shell -n pre-trigger "Break before pre-trigger"
+source_hook pre-trigger
 
 udevadm control --reload > /dev/null 2>&1 || :
 


### PR DESCRIPTION
Currently, pre-trigger hooks are sourced before the breakpoint, not after. It's the only `rd.break` option with this behavior, even all the non-systemd breakpoints defined in 80base/init.sh work as intended.

Follow-up for 22137f9cac5ceb1a1d0ff8c5cab3d7bb8b582e33

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
