### PR TITLE
feat(rngd): only install rngd dracut module if explicitly included

### DIFF
--- a/modules.d/16rngd/module-setup.sh
+++ b/modules.d/16rngd/module-setup.sh
@@ -23,7 +23,7 @@ check() {
     require_binaries rngd || return 1
     [[ -e "${systemdsystemunitdir}/rngd.service" ]] || return 1
 
-    return 0
+    return 255
 }
 
 depends() {


### PR DESCRIPTION
rngd dracut module is not needed anymore since kernel 5.6 (released 2020) because /dev/random does not block anymore.

This PR does not remove support for the rngd dracut module - it simply now not installed by default.

According to dracut compatibility table, currently our CI containers are all kernel version 6.12 or higher - https://dracut-ng.github.io/dracut/developer/compatibility.html

See https://github.com/torvalds/linux/commit/30c08efec8884fb106b8e57094baa51bb4c44e32

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
