### PR TITLE
ci(debian): remove isc-dhcp-server from ci

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -58,7 +58,6 @@ RUN case $(dpkg --print-architecture) in \
     iputils-arping \
     iputils-ping \
     ipxe-qemu \
-    isc-dhcp-server \
     iscsiuio \
     jq \
     kbd \


### PR DESCRIPTION
isc-dhcp-server is unmaintained and has been removed from Debian.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
