### PR TITLE
docs: fix typo in hacking guide

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/hacking.adoc
+++ b/doc_site/modules/ROOT/pages/developer/hacking.adoc
@@ -106,7 +106,7 @@ https://github.com/orgs/dracut-ng/packages[github `dracut-ng` containers].
 Default container is `fedora`.
 
 If the container supports arm64, and the test.sh script is run on an arm64
-enviroment, the test would also run using an arm64 container.
+environment, the test would also run using an arm64 container.
 
 Run only specific test::
 e.g. only runs the 10, 20 tests inside the default container.


### PR DESCRIPTION
Typo in the hacking guide: `enviroment` -> `environment`.

`doc_site/modules/ROOT/pages/developer/hacking.adoc:109`. It is the only instance under `doc_site`.

### Checklist
- [ ] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Documentation wording only, so there is nothing to test and no code or tests to add.
