### PR TITLE
fix(base): sanitize message written by die() to the emergency hook

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -433,7 +433,7 @@ die() {
     } > /dev/kmsg
 
     {
-        echo "warn dracut: FATAL: \"$*\""
+        printf "warn dracut: FATAL: '%s'\n" "$(escape "$*")"
         echo "warn dracut: Refusing to continue"
     } >> $hookdir/emergency/01-die.sh
     [ -d /run/initramfs ] || mkdir -p -- /run/initramfs


### PR DESCRIPTION
It is possible that not all messages passed to `die()` are trusted. E.g., netroot.sh calls:

```
die "No handler for netroot type '$netroot'"
```

The value of `$netroot` can be taken from the DHCP root-path option; that would be safe thanks to previous fixes that escape DHCP values before writing them to dhclient's dhcpopts files.

But, it may also be taken directly from the `netroot=` kernel command line option, allowing any type of characters.

Use the `escape()` helper and single-quote the message instead, which is the safe usage documented for escape().

Fixes: CVE-2026-15816

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
