### PR TITLE
docs: generic is no longer the default mode

### DIFF
--- a/doc_site/modules/ROOT/pages/index.adoc
+++ b/doc_site/modules/ROOT/pages/index.adoc
@@ -134,7 +134,7 @@ mounted over the top.
 If the systemd module is used in the initramfs, the ordering of the services
 started looks like xref:man/dracut.bootup.7.adoc[].
 
-== Host v Default mode
+== Host-only versus generic mode
 
 Dracut can operate in two modes
 
@@ -142,7 +142,7 @@ host-only mode:: dracut will generate a smaller customized initramfs image
 which contains only whatever is necessary to boot based on examining the
 running system.
 
-default mode:: dracut will generate a larger, but more generic, initramfs
+generic mode:: dracut will generate a larger, but more generic, initramfs
 image.  This is important for generic kernels, or if you are switching hardware
 for an installed system.
 


### PR DESCRIPTION
Do not use "default" as the name of the mode, as the default mode is configurable. Spell out "generic" and "host-only" modes whenever possible.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
