### PR TITLE
docs: typo in dracut.cmdline

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -251,7 +251,7 @@ rd.vconsole.keymap=de-latin1-nodeadkeys
 --
 
 **rd.vconsole.keymap.ext=**__<list of keymap base file names>__::
-    list of extra keymaps to bo loaded (sep. by space); will be written as
+    list of extra keymaps to be loaded (sep. by space); will be written as
     EXT_KEYMAP to _/etc/vconsole.conf_ in the initramfs
 
 **rd.vconsole.unicode**::

--- a/modules.d/20i18n/README
+++ b/modules.d/20i18n/README
@@ -49,7 +49,7 @@ runtime:
     KEYMAP - keyboard translation table loaded by loadkeys
     KEYTABLE - base name for keyboard translation table; if UNICODE is
     true, Unicode version will be loaded. Overrides KEYMAP.
-    EXT_KEYMAPS - list of extra keymaps to bo loaded (sep. by space)
+    EXT_KEYMAPS - list of extra keymaps to be loaded (sep. by space)
     UNICODE - boolean, indicating UTF-8 mode
     FONT - console font
     FONT_MAP - see description of '-m' parameter in setfont manual


### PR DESCRIPTION
Fix the type and change "to bo loaded" to "to be loaded".

Fixes: https://github.com/dracutdevs/dracut/issues/2734

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
