### PR TITLE
fix(dracut): disable hostonly-cmdline by default in container

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1400,6 +1400,16 @@ if [[ ${hostonly-} ]] && ! [[ $hostonly_cmdline ]] && ! is_chroot; then
     hostonly_cmdline="yes"
 fi
 
+if type -P systemd-detect-virt &> /dev/null && container=$(systemd-detect-virt -c) &> /dev/null; then
+    export DRACUT_NO_MKNOD=1
+    dinfo "Detected $container container."
+
+    if [[ ${hostonly-} ]] && ! [[ $hostonly_cmdline ]]; then
+        # Disable hostonly-cmdline by default in hostonly mode when container detected
+        hostonly_cmdline="no"
+    fi
+fi
+
 case $hostonly_mode in
     '')
         [[ ${hostonly-} ]] && hostonly_mode="sloppy"
@@ -2035,11 +2045,6 @@ else
         [[ -d ${_dest%/*} ]] && _dest=$(readlink -f "${_dest%/*}")/${_dest##*/}
         ln -sfn -- "$(convert_abs_rel "${_dest}" "${_source}")" "${dstdir}/${_dest}"
     }
-fi
-
-if type -P systemd-detect-virt &> /dev/null && container=$(systemd-detect-virt -c) &> /dev/null; then
-    export DRACUT_NO_MKNOD=1
-    dinfo "Detected $container container."
 fi
 
 if [[ $persistent_policy == "mapper" ]]; then

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -198,7 +198,7 @@ WARNING: If chrooted to another root other than the real root device, use
 *hostonly_cmdline=*"__{yes|no}__"::
 Store host-specific kernel command-line arguments in the initramfs when
 set to "yes". If left unset, it automatically enables when **hostonly="yes"**
-(unless running inside a chroot). (default=unset)
+(unless running inside a chroot or inside a container). (default=unset)
 
 *hostonly_nics+=*" [__<nic>__[ __<nic>__ ...]] "::
 Only enable listed NICs in the initramfs. The list can be empty, so other


### PR DESCRIPTION
Disable hostonly-cmdline by default in hostonly mode when container detected.

Follow-up to 67d8287 .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
