### PR TITLE
test(SYSTEMD-INITRD): systemd dracut module does not depend on base

### DIFF
--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -50,16 +50,16 @@ test_setup() {
     # vanilla kernel-independent systemd-based minimal initrd without dracut specific customizations
     # since dracut-systemd is not included in the generated initrd, only systemd options are supported during boot
     test_dracut --keep --no-kernel \
-        --omit "test systemd-sysctl systemd-modules-load" \
-        -m "systemd-initrd base" \
+        --omit "test" \
+        -m "systemd-initrd" \
         "$TESTDIR"/initramfs-systemd-initrd
 
     (
         # remove all shell scripts and the shell itself from the generated initramfs
         # to demonstrate a shell-less optimized boot
         cd "$TESTDIR"/initrd/dracut.*/initramfs
-        rm "$(realpath bin/sh)"
-        rm bin/sh
+        rm -f "$(realpath bin/sh)"
+        rm -f bin/sh
         find . -name "*.sh" -delete
 
         # verify that dracut systemd services are not included


### PR DESCRIPTION
systemd-based minimal initrd does not depend on base.

Let's improve the test coverage for the case where base is optional for a strict locked down systemd-based initrd.

This is a test case/test coverage only change, no change in actual dracut code or dracut module.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
