### PR TITLE
test: prefer test_marker_check over check_qemu_log

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -8,13 +8,15 @@ TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 }
 
 test_setup() {

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -22,13 +22,19 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.btrfs root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+
+    if ! test_marker_check; then
+        client_test_end "FAILED"
+        return 1
+    fi
 
     client_test_end
 }

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -8,13 +8,15 @@ TEST_DESCRIPTION="initramfs created from sysroot"
 
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 }
 
 test_setup() {

--- a/test/TEST-14-HOOKS/test.sh
+++ b/test/TEST-14-HOOKS/test.sh
@@ -8,13 +8,15 @@ TEST_DESCRIPTION="dracut hooks in various locations"
 
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 }
 
 add_hook() {

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -37,6 +37,7 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR/${disk}-1.img" disk1
 
     if ! grep -qF 'degraded' "$test_name"; then
@@ -50,11 +51,12 @@ client_run() {
         TEST_KERNEL_CMDLINE+=" root=LABEL=dracut "
     fi
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE ro $client_opts " \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 
     client_test_end
 }

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -14,15 +14,17 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
     qemu_add_drive disk_args "$TESTDIR"/overlay.img overlay
     qemu_add_drive disk_args "$TESTDIR"/crypt.img crypt
 
+    test_marker_reset
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 
     client_test_end
 }

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -26,22 +26,25 @@ test_run() {
     client_test_start "$LUKSARGS"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/disk-1.img disk1
     qemu_add_drive disk_args "$TESTDIR"/disk-2.img disk2
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root ro rd.auto rootwait $LUKSARGS" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
     client_test_end
 
     client_test_start "Any LUKS"
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rd.auto" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
     client_test_end
 
     return 0

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -24,15 +24,21 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
     qemu_add_drive disk_args "$TESTDIR"/root_erofs.img root_erofs
     qemu_add_drive disk_args "$TESTDIR"/root_iso.img root_iso
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE rd.overlay root=live:/dev/disk/by-label/dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+
+    if ! test_marker_check; then
+        client_test_end "FAILED"
+        return 1
+    fi
 
     client_test_end
 }

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -11,13 +11,15 @@ test_check() {
 #DEBUGFAIL="rd.shell=1 rd.break=pre-mount"
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE \"root=LABEL=  rdinit=/bin/sh\" systemd.log_target=console init=/sbin/init" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 }
 
 is_systemd_version_greater_or_equal() {

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -24,15 +24,21 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.btrfs root
     qemu_add_drive disk_args "$TESTDIR"/root_crypt.btrfs root_crypt
     qemu_add_drive disk_args "$TESTDIR"/usr.btrfs usr
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut systemd.default_device_timeout_sec=0 $TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+
+    if ! test_marker_check; then
+        client_test_end "FAILED"
+        return 1
+    fi
 
     client_test_end
 }

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -18,13 +18,19 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut systemd.default_device_timeout_sec=0 $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+
+    if ! test_marker_check; then
+        client_test_end "FAILED"
+        return 1
+    fi
 
     client_test_end
 }

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -15,20 +15,23 @@ test_check() {
 
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd
-    check_qemu_log
+    test_marker_check
 
     # rescue (non-hostonly) boot
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
-    check_qemu_log
+    test_marker_check
 }
 
 test_setup() {

--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -19,15 +19,17 @@ test_check() {
 #DEBUGFAIL="rd.shell=1 rd.break=pre-mount"
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
     qemu_add_drive disk_args "$TESTDIR"/mnt.img mnt
 
     # This test should fail if rd.driver.export is not passed at kernel command-line
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.driver.export" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 }
 
 test_setup() {

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -11,15 +11,17 @@ TEST_DESCRIPTION="bring up network without netroot set with $USE_NETWORK"
 
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         -device "virtio-net-pci,netdev=lan0" \
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.neednet=1" \
         -initrd "$TESTDIR"/initramfs.testing
-    check_qemu_log
+    test_marker_check
 }
 
 test_setup() {


### PR DESCRIPTION
Reading the QEMU log instead of requiring to write to a `marker.img` inside the VM is is less reliable and prone to nondeterminism.

Fixes: https://github.com/dracut-ng/dracut/issues/2233

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
