### PR TITLE
ci: re-stabilize regression test suite by skipping known failures

### DIFF
--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -46,6 +46,10 @@ jobs:
                     - "80"
                     - "81"
                     - "82"
+                exclude:
+                    # https://github.com/dracut-ng/dracut/issues/2061
+                    -  test: "82"
+
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -39,10 +39,6 @@ jobs:
                 test:
                     - "50"
                     - "60"
-                    - "72"
-                exclude:
-                    - container: gentoo:latest
-                      test: "72"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -62,6 +62,9 @@ jobs:
                       test: "61"
                     - container: ubuntu:rolling
                       test: "61"
+                    # https://github.com/dracut-ng/dracut/issues/2522
+                    - container: fedora:rawhide
+                      test: "60"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -192,9 +192,7 @@ jobs:
                     - "60"
                     - "61"
                 exclude:
-                    # In Debian/Ubuntu both chrony and systemd-timesyncd provide
-                    # the virtual package time-daemon, so systemd-timesyncd
-                    # would have to be removed, breaking test 41.
+                    # https://github.com/dracut-ng/dracut/issues/2541
                     - container: ubuntu:devel
                       test: "61"
         container:


### PR DESCRIPTION
- ci: exclude running DRACUT-CPIO, it is known to fail
- ci: exclude running NFS test on rawhide
- ci: update obsolete comment on why chrony test is not run on Ubuntu
- ci: obsolete some network-legacy testing

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
