### PR TITLE
Fix cross building an initramfs

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/cross_compiling.adoc
+++ b/doc_site/modules/ROOT/pages/developer/cross_compiling.adoc
@@ -22,6 +22,11 @@ This variable can also be set externally to dracut without using option
 There are other details that are necessary to tweak to be able to
 run on cross-compiled (a.k.a. foreign) binaries.
 
+Extra environment variables needed to run dracut on the sysroot are documented
+in man:dracut[8]. If dracut is installed inside your sysroot, you can use it
+from there as long as compatible (i.e., same version) dracut executables for
+the host are on `PATH`.
+
 dracut uses these crucial utilities during its operation:
 
 == ldd
@@ -42,5 +47,9 @@ https://gist.github.com/jerome-pouiller/c403786c1394f53f44a3b61214489e6f
 
 ldconfig in GLIBC as is does support a sysroot with its -r option.
 
-Extra environment variables needed to run dracut on the sysroot are
-documented in the dracut(8) man page.
+== Runtime tools
+
+A few dracut tools (`dracut-extractinitrd`, `dracut-util`) are used at runtime
+(from the initramfs, or fully booted system). To be usable, they need to be
+cross-compiled and installed into the sysroot, or see **DRACUT_RUNTIMEDIR** in
+man:dracut[8] for tools only needed in the initramfs (namely, `dracut-util`).

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1114,11 +1114,11 @@ inst() {
     fi
     [[ -e ${dstdir}/"${2:-$1}" ]] && return 0 # already there
     [[ ${DRACUT_RESOLVE_LAZY-} ]] || _resolve_deps=1
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"
         return $_ret
     fi
 }
@@ -1138,11 +1138,11 @@ inst_binary() {
 inst_script() {
     local _ret _resolve_deps
     [[ ${DRACUT_RESOLVE_LAZY-} ]] || _resolve_deps=1
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"
         return "$_ret"
     fi
 }
@@ -1161,7 +1161,7 @@ inst_simple() {
     fi
     [[ -e ${dstdir}/"${2:-$1}" ]] && return 0 # already there
     if [[ $1 == /* ]]; then
-        if [[ ! -e ${dracutsysrootdir-}/${1#"${dracutsysrootdir-}"} ]]; then
+        if [[ ! -e ${dracutsysrootdir-}/${1#"${dracutsysrootdir-}"} ]] && [[ ! -e ${dracutbasedir-}/${1#"${dracutbasedir-}"} ]]; then
             dwarn "no source: '$1'!"
             return 1
         fi
@@ -1169,11 +1169,11 @@ inst_simple() {
         dwarn "no source: '$1'!"
         return 1
     fi
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"
         return $_ret
     fi
 }

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1451,7 +1451,7 @@ optional_hostonly() {
 }
 
 # helper function for check() in module-setup.sh
-# to check for required installed binaries
+# to check for required binaries to be installed into initrd
 # issues a standardized warning message
 require_binaries() {
     local _module_name="${moddir##*/}"

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1486,6 +1486,22 @@ require_any_binary() {
 }
 
 # helper function for check() in module-setup.sh
+# to check for required binaries used while building initrd
+# issues a standardized warning message
+require_binaries_host() {
+    local _module_name="${moddir##*/}"
+    local _ret=0
+
+    for cmd in "$@"; do
+        if ! command -v "$cmd" &> /dev/null; then
+            ddebug "Module '${_module_name#[0-9][0-9]}' will not be installed, because host command '$cmd' could not be found!"
+            ((_ret++))
+        fi
+    done
+    return "$_ret"
+}
+
+# helper function for check() in module-setup.sh
 # to check for required kernel modules
 # issues a standardized warning message
 require_kernel_modules() {

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -58,8 +58,9 @@ is_elf() {
     [[ $(head -c 4 "$1") == $'\x7fELF' ]]
 }
 
-# find a binary.  If we were not passed the full path directly,
-# search in the usual places to find the binary.
+# Find a binary to be installed into the initrd. If we were not passed the full
+# path directly, search in the usual places to find the binary
+# (DRACUT_INSTALL_PATH if set, otherwise PATH).
 find_binary() {
     local _delim
     local _path
@@ -94,7 +95,7 @@ find_binary() {
             printf "%s\n" "${_path}"
             return 0
         fi
-    done <<< "${PATH}:"
+    done <<< "${DRACUT_INSTALL_PATH:-${PATH}}:"
 
     [[ -n ${dracutsysrootdir-} ]] && return 1
     type -P "${1##*/}"

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1127,11 +1127,11 @@ inst() {
 inst_binary() {
     local _ret _resolve_deps
     [[ ${DRACUT_RESOLVE_LAZY-} ]] || _resolve_deps=1
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${DRACUT_RUNTIMEDIR:+-B "$DRACUT_RUNTIMEDIR"}} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${DRACUT_RUNTIMEDIR:+-B "$DRACUT_RUNTIMEDIR"}} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"
         return "$_ret"
     fi
 }

--- a/dracut.sh
+++ b/dracut.sh
@@ -1002,6 +1002,13 @@ if [[ ! -d $dracutbasedir ]]; then
     printf "dracut[F]: base directory '%s' does not exist.\n" "$dracutbasedir" >&2
     exit 1
 fi
+if ! [[ ${DRACUT_RUNTIMEDIR:-} ]]; then
+    if ! [[ ${dracutsysrootdir-} ]]; then
+        DRACUT_RUNTIMEDIR="${dracutbasedir}"
+    else
+        DRACUT_RUNTIMEDIR="${dracutsysrootdir-}"/usr/lib/dracut
+    fi
+fi
 
 export DRACUT_ARCH=${DRACUT_ARCH:-$(uname -m)}
 
@@ -2580,7 +2587,7 @@ for dev in "${!host_fs_types[@]}"; do
     fi
 done
 
-export initdir dracutbasedir \
+export initdir dracutbasedir DRACUT_RUNTIMEDIR \
     dracutmodules force_add_dracutmodules add_dracutmodules omit_dracutmodules \
     prefer_dracutmodules mods_to_load \
     fw_dir drivers_dir debug no_kernel kernel_only \

--- a/man/dracut-install.8.adoc
+++ b/man/dracut-install.8.adoc
@@ -10,11 +10,11 @@ dracut-install - install files or kernel modules into initramfs staging director
 
 SYNOPSIS
 --------
-**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_] [_OPTION_]... --all _SOURCE_...
+**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_ [-B _DRACUTDIR_]] [_OPTION_]... --all _SOURCE_...
 
-**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_] [_OPTION_]... _SOURCE_ _DEST_
+**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_ [-B _DRACUTDIR_]] [_OPTION_]... _SOURCE_ _DEST_
 
-**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_] [_OPTION_]... --module _KERNELMODULE_...
+**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_ [-B _DRACUTDIR_]] [_OPTION_]... --module _KERNELMODULE_...
 
 DESCRIPTION
 -----------
@@ -41,6 +41,11 @@ OPTIONS
 
 **-r**, **--sysrootdir**::
     Install all files from _SYSROOTDIR_
+
+**-B**, **--dracutdir** _DRACUTDIR_::
+    Allow installing files from the dracut installation at _DRACUTDIR_ in
+    addition to _SYSROOTDIR_ (needed when using dracut installed on the host,
+    outside _SYSROOTDIR_). Only has an effect if **--sysrootdir** is used.
 
 **-a**, **--all**::
     Install all _SOURCE_ arguments to _DESTROOTDIR_

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -728,6 +728,17 @@ _DRACUT_TESTBIN_::
 Default:
     _/bin/sh_
 
+_DRACUT_RUNTIMEDIR_::
+    overrides the directory containing compiled dracut tools to be installed
+    into the initramfs, e.g. **dracut-util**. Used with **--sysroot**. If using
+    **dracut** installed on the host (outside the sysroot) to build an
+    initramfs for a cross-compiled sysroot, use this option to set the location
+    of cross-compiled dracut runtime tools.
++
+Default:
+    _$dracutsysrootdir/usr/lib/dracut_ with **--sysroot**,
+    _$prefix/lib/dracut_ otherwise
+
 _DRACUT_INSTALL_::
     overrides path and options for executing _dracut-install_ internally.
     Optional. Can be used to debug _dracut-install_ while running the

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -395,15 +395,14 @@ dracut releases.
 
 ==== require_binaries
 
-Helper function for check() in module-setup.sh to check for required installed binaries.
-All of the binaries listed in the arguments of this function should exists in the host.
+Helper function for check() in module-setup.sh to check for required binaries to be installed into initrd.
+All of the binaries listed in the arguments of this function must be available in `DRACUT_INSTALL_PATH` if set, otherwise in `PATH`. If using **-sysroot**, the search path is within the sysroot directory.
 Issues a standardized warning message.
 
 ==== require_any_binary
 
-Helper function for check() in module-setup.sh to check for required installed binaries.
-At least one of the binaries listed in the arguments of this function should exists in
-the host.
+Helper function for check() in module-setup.sh to check for required binaries to be installed into initrd.
+At least one of the binaries listed in the arguments of this function must be available in `DRACUT_INSTALL_PATH` if set, otherwise in `PATH`. If using **-sysroot**, the search path is within the sysroot directory.
 Issues a standardized warning message.
 
 ==== require_binaries_host

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -406,6 +406,12 @@ At least one of the binaries listed in the arguments of this function should exi
 the host.
 Issues a standardized warning message.
 
+==== require_binaries_host
+
+Helper function for check() in module-setup.sh to check for required binaries used while building initrd.
+All of the binaries listed in the arguments of this function must exist in `PATH`.
+Issues a standardized warning message.
+
 ==== require_kernel_modules
 
 Helper function for check() in module-setup.sh to check for required kernel modules.

--- a/modules.d/74squash-erofs/module-setup.sh
+++ b/modules.d/74squash-erofs/module-setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 check() {
-    require_binaries mkfs.erofs fsck.erofs || return 1
+    require_binaries_host mkfs.erofs || return 1
+    require_binaries fsck.erofs || return 1
     require_kernel_modules erofs || return 1
 
     return 255

--- a/modules.d/74squash-squashfs/module-setup.sh
+++ b/modules.d/74squash-squashfs/module-setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 check() {
-    require_binaries mksquashfs unsquashfs || return 1
+    require_binaries_host mksquashfs || return 1
+    require_binaries unsquashfs || return 1
     require_kernel_modules squashfs || return 1
 
     return 255

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -51,7 +51,7 @@ install() {
         reboot \
         sysctl
 
-    inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
+    inst_binary "${DRACUT_RUNTIMEDIR}/dracut-util" "/usr/bin/dracut-util"
 
     ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
     ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -81,6 +81,8 @@ static bool no_xattr = false;
 static char *destrootdir = NULL;
 static char *sysrootdir = NULL;
 static size_t sysrootdirlen = 0;
+static char *dracutdir = NULL;
+static size_t dracutdirlen = 0;
 static char *kerneldir = NULL;
 static size_t kerneldirlen = 0;
 static char **firmwaredirs = NULL;
@@ -1401,7 +1403,10 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
                         fullsrcpath = strdup(orig_src);
                 } else {
                         src = orig_src;
-                        _asprintf(&fullsrcpath, "%s%s", sysrootdir, src);
+                        if (dracutdirlen && strncmp(orig_src, dracutdir, dracutdirlen) == 0)
+                                fullsrcpath = strdup(orig_src);
+                        else
+                                _asprintf(&fullsrcpath, "%s%s", sysrootdir, src);
                 }
                 if (strncmp(orig_dst, sysrootdir, sysrootdirlen) == 0)
                         dst = orig_dst + sysrootdirlen;
@@ -1587,9 +1592,9 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
 static void usage(int status)
 {
         /*                                                                                */
-        printf("Usage: %s -D DESTROOTDIR [-r SYSROOTDIR] [OPTION]... -a SOURCE...\n"
-               "or: %s -D DESTROOTDIR [-r SYSROOTDIR] [OPTION]... SOURCE DEST\n"
-               "or: %s -D DESTROOTDIR [-r SYSROOTDIR] [OPTION]... -m KERNELMODULE [KERNELMODULE …]\n"
+        printf("Usage: %s -D DESTROOTDIR [-r SYSROOTDIR [-B DRACUTDIR]] [OPTION]... -a SOURCE...\n"
+               "or: %s -D DESTROOTDIR [-r SYSROOTDIR [-B DRACUTDIR]] [OPTION]... SOURCE DEST\n"
+               "or: %s -D DESTROOTDIR [-r SYSROOTDIR [-B DRACUTDIR]] [OPTION]... -m KERNELMODULE [KERNELMODULE …]\n"
                "\n"
                "Install SOURCE (from rootfs or SYSROOTDIR) to DEST in DESTROOTDIR with all needed dependencies.\n"
                "\n"
@@ -1600,6 +1605,9 @@ static void usage(int status)
                "\n"
                "  -D --destrootdir  Install all files to DESTROOTDIR as the root\n"
                "  -r --sysrootdir   Install all files from SYSROOTDIR\n"
+               "  -B --dracutdir    Allow installing files from the dracut installation\n"
+               "                    at DRACUTDIR in addition to SYSROOTDIR (needed when\n"
+               "                    using dracut installed outside SYSROOTDIR)\n"
                "  -a --all          Install all SOURCE arguments to DESTROOTDIR\n"
                "  -o --optional     If SOURCE does not exist, do not fail\n"
                "  -d --dir          SOURCE is a directory\n"
@@ -1678,10 +1686,11 @@ static int parse_argv(int argc, char *argv[])
                 {"firmwaredirs", required_argument, NULL, ARG_FIRMWAREDIRS},
                 {"json-supported", no_argument, NULL, ARG_JSON_SUPPORTED},
                 {"dry-run", no_argument, NULL, 'n'},
+                {"dracutdir", required_argument, NULL, 'B'},
                 {NULL, 0, NULL, 0}
         };
 
-        while ((c = getopt_long(argc, argv, "madfhlL:oD:Hr:Rp:P:s:S:N:vn", options, NULL)) != -1) {
+        while ((c = getopt_long(argc, argv, "madfhlL:oD:Hr:Rp:P:s:S:N:vnB:", options, NULL)) != -1) {
                 switch (c) {
                 case ARG_VERSION:
                         puts(PROGRAM_VERSION_STRING);
@@ -1795,6 +1804,17 @@ static int parse_argv(int argc, char *argv[])
 #endif
                 case 'n':
                         arg_dry_run = true;
+                        break;
+                case 'B':
+                        dracutdir = optarg;
+                        dracutdirlen = strlen(dracutdir);
+                        if (dracutdirlen < 1) {
+                                log_error("dracutdir is set but empty!");
+                                exit(EXIT_FAILURE);
+                        }
+                        /* ignore trailing '/' */
+                        if (dracutdir[dracutdirlen-1] == '/')
+                                dracutdirlen--;
                         break;
                 default:
                         usage(EXIT_FAILURE);


### PR DESCRIPTION
Even though `--sysroot` is supported, much of the current Dracut code assumes that:
1. Dracut is installed in the sysroot (if any)
2. The host building the initramfs can run executables from the sysroot

When cross-building an initramfs, the second assumption does not hold, and for small embedded systems the first is at least undesirable: the initramfs is created on the build host, only the artifact is needed on the target, including a full Dracut install in the target rootfs is unnecessary baggage.

Fixes: #557

### General idea

The cross-build is either supposed to use Dracut installed on the host system ("host Dracut", `dracutbasedir` outside the sysroot), or Dracut as installed in the sysroot ("target Dracut"). The catch in either case are the compiled executables, so I added environment variables to configure them:

* `DRACUT_BINDIR`: location of executables used during initramfs build. By default this is `dracutbasedir`, when using cross-compiled target Dracut (so executables can't run on the host), override this to use host binaries.
* `DRACUT_RUNTIMEDIR`: location of executables to install into initramfs. When using host Dracut with `--sysroot`, this needs to point to the location of cross-compiled executables (at least `dracut-util`). In many cases the default of `${dracutsysrootdir}/usr/lib/dracut` will just work, but it could be elsewhere, e.g. Buildroot could use `$(STAGING_DIR)/lib/dracut`. Without `--sysroot` the default is simply `dracutbasedir`.

### Changes to make that work

* set `dracutbasedir` based on install location, so running `$dracutsysrootdir/usr/bin/dracut` will automatically use modules etc. installed in the sysroot
* Allow installing from `dracutbasedir` (possibly outside `dracutsysrootdir`) when using sysroot (executables excluded), for files from host Dracut modules
* Allow installing executables from `DRACUT_RUNTIMEDIR` (possibly outside `dracutsysrootdir`) when using sysroot
* functions: honor `DRACUT_INSTALL_PATH` in find_binary
* functions: do not try to install udev rules from `$dracutbasedir/rules.d`
* base: install dracut-util from `DRACUT_RUNTIMEDIR`
* ~~busybox: allow overriding the list of applets, to avoid running `busybox --list` (which won't work if it's a cross-compiled executable). The `DRACUT_MODULE_BUSYBOX_LINKS` environment variable must be the path of a list of applets, using the `busybox.links` file from Busybox build is recommended.~~ (moved to #2649)

Some modules I didn't touch might still try to call random executables, but that can be fixed separately.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
