### PR TITLE
test: prefer test_marker_check over check_qemu_log

### DIFF
--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -24,12 +24,18 @@ client_run() {
     local append="$2"
 
     client_test_start "$test_name"
+
+    declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
+
+    test_marker_reset
     "$testdir"/run-qemu \
+        "${disk_args[@]}" \
         -device "virtio-net-pci,netdev=lan0" \
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         -append "$append $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR/initramfs.testing"
-    check_qemu_log
+    test_marker_check
     client_test_end
 }
 

--- a/test/TEST-45-SYSTEMD-IMPORT/test.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/test.sh
@@ -27,12 +27,17 @@ client_run() {
 
     client_test_start "$test_name"
 
+    declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
+
+    test_marker_reset
     "$testdir"/run-qemu \
+        "${disk_args[@]}" \
         -device "virtio-net-pci,netdev=lan0" \
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         -append "$append $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR/initramfs.testing"
-    check_qemu_log
+    test_marker_check
 
     client_test_end
 }

--- a/test/TEST-46-SYSTEMD-SYSEXT/test.sh
+++ b/test/TEST-46-SYSTEMD-SYSEXT/test.sh
@@ -20,18 +20,22 @@ test_check() {
 
 test_run() {
     declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_args "$TESTDIR"/marker2.img marker2 1
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
 
-    # Check if the message "All OK" is in QEMU logs
-    check_qemu_log
+    test_marker_check
 
-    # Also check if the message "dracut-sysext-success" is in QEMU logs
-    check_qemu_log "$QEMU_LOGFILE" "dracut-sysext-success"
+    # Also check if the message "dracut-sysext-success" is in the marker
+    if ! test_marker_check "dracut-sysext-success" marker2.img; then
+        return 1
+    fi
 }
 
 test_setup() {
@@ -93,7 +97,7 @@ test_setup() {
     pushd "$TESTDIR/$sysext_name/usr/lib"
     touch "dracut/hooks/pre-pivot/$sysext_name.sh"
     chmod +x "dracut/hooks/pre-pivot/$sysext_name.sh"
-    echo "[ -e \"/etc/$confext_name.marker\" ] && warn \"\$(cat /etc/$confext_name.marker)\"" > "dracut/hooks/pre-pivot/50-$sysext_name.sh"
+    echo "[ -e \"/etc/$confext_name.marker\" ] && cat /etc/$confext_name.marker | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2 status=none" > "dracut/hooks/pre-pivot/50-$sysext_name.sh"
     mkdir -p "extension-release.d"
     {
         grep -e "^ID=" -e "^VERSION_ID=" /etc/os-release
@@ -113,6 +117,7 @@ test_setup() {
     # signature checking
     test_dracut \
         --no-hostonly-cmdline \
+        --install "dd" \
         -i "$TESTDIR/$confext_name.raw" "/.extra/confext/$confext_name.raw" \
         -i "$TESTDIR/$sysext_name.raw" "/.extra/sysext/$sysext_name.raw" \
         -i "$TESTDIR/$crt_dir/dracut.crt" "/etc/verity.d/dracut.crt" \

--- a/test/TEST-61-CHRONY/test.sh
+++ b/test/TEST-61-CHRONY/test.sh
@@ -37,6 +37,7 @@ client_run() {
     # - -rtc "base=...,clock=vm" allows to disconnect vm time from host time
     # - initcall_blacklist=rtc_cmos_init (x86_64) / efi_rtc_init (aarch64)
     #   instructs the kernel to avoid trying to sync the clock
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -rtc "base=$FAKE_TIME,clock=vm" \
@@ -47,9 +48,9 @@ client_run() {
 
     # The "nook" variable controls whether a failed test is considered good
     if [[ $nook != 1 ]]; then
-        check_qemu_log
+        test_marker_check
     else
-        check_qemu_log || :
+        test_marker_check || :
     fi
 
     client_test_end
@@ -58,6 +59,7 @@ client_run() {
 test_run() {
     declare -a disk_args=()
 
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     start_webserver "HTTPS" "$SSL_CERT"


### PR DESCRIPTION
Reading the QEMU log instead of requiring to write to a `marker.img` inside the VM is is less reliable and prone to nondeterminism.

Fixes: dracut-ng#2233
Follow-up to a102337

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
