### PR TITLE
test(SYSTEMD-INITRD): verify that dracut-lib.sh is not installed

### DIFF
--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -61,12 +61,16 @@ test_setup() {
         "$TESTDIR"/initramfs-systemd-initrd
 
     (
-        # remove all shell scripts and the shell itself from the generated initramfs
-        # to demonstrate a shell-less optimized boot
+        # remove the shell itself from the generated initramfs to demonstrate a shell-less optimized boot
         cd "$TESTDIR"/initrd/dracut.*/initramfs
         rm -f "$(realpath bin/sh)"
         rm -f bin/sh
-        find . -name "*.sh" -delete
+
+        # verify that dracut-lib.sh is not included to confirm that shell scripts could not execute
+        if [ -e "lib/dracut-lib.sh" ]; then
+            echo "unexpectedly dracut-lib.sh is found in the generated initramfs"
+            return 1
+        fi
 
         # verify that dracut systemd services are not included
         cd usr/lib/systemd/system/


### PR DESCRIPTION
Missing dracut-lib.sh file is a good way to confirm that shell scripts are not installed.

It is no longer needed to remove "*.sh" files, none are installed anyways, so this is just a no-op.

Follow-up to 57623b9 .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
