### PR TITLE
ci: create common multi-arch container tag in the same step as image build

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -47,23 +47,30 @@ jobs:
                     - dockerfile: Dockerfile-azurelinux
                       tag: azurelinux:latest
                       registry: mcr.microsoft.com
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-fedora
                       tag: centos:latest
                       registry: quay.io/centos
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-debian
                       tag: debian:sid
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-fedora
                       tag: fedora:rawhide
                       registry: registry.fedoraproject.org
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-gentoo
                       tag: gentoo:amd64-openrc
                       option: amd64-openrc
+                      platforms: ['amd']
                     - dockerfile: Dockerfile-gentoo
                       tag: gentoo:arm64-openrc
                       option: arm64-openrc
+                      platforms: ['arm']
                     - dockerfile: Dockerfile-gentoo
                       tag: gentoo:latest
                       option: systemd
+                      platforms: ['amd', 'arm']
                 exclude:
                     # arch container does not support arm
                     - config: {tag: 'arch:latest'}
@@ -96,34 +103,8 @@ jobs:
                       DISTRIBUTION=${{ matrix.config.tag }}
                       REGISTRY=${{ matrix.config.registry }}
                       OPTION=${{ matrix.config.option }}
-    manifest:
-        needs: container-extra
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        name: ${{ matrix.config.tag }}
-        concurrency:
-            group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
-            cancel-in-progress: true
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                config:
-                    - {tag: 'azurelinux:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'centos:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'debian:sid', platforms: ['amd', 'arm']}
-                    - {tag: 'fedora:rawhide', platforms: ['amd', 'arm']}
-                    - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
-                    - {tag: 'gentoo:arm64-openrc', platforms: ['arm']}
-        steps:
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v4
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
             - name: Create and Push Multi-Arch Manifest
+              if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
               run: |
                   tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
                   images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,23 +43,32 @@ jobs:
                 config:
                     - dockerfile: Dockerfile-alpine
                       tag: alpine:edge
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-alpine
                       tag: alpine:busybox-edge
+                      platforms: ['amd', 'arm']
                       option: busybox
                     - dockerfile: Dockerfile-arch
                       tag: arch:latest
+                      platforms: ['amd']
                     - dockerfile: Dockerfile-debian
                       tag: debian:latest
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-fedora
                       tag: fedora:latest
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-opensuse
                       tag: opensuse:latest
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-debian
                       tag: ubuntu:devel
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-debian
                       tag: ubuntu:rolling
+                      platforms: ['amd', 'arm']
                     - dockerfile: Dockerfile-void
                       tag: void:latest
+                      platforms: ['amd', 'arm']
                 exclude:
                     # arch container does not support arm
                     - config: {tag: 'arch:latest'}
@@ -88,36 +97,8 @@ jobs:
                   build-args: |
                       DISTRIBUTION=${{ matrix.config.tag }}
                       OPTION=${{ matrix.config.option }}
-    manifest:
-        needs: container
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        name: ${{ matrix.config.tag }}
-        concurrency:
-            group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
-            cancel-in-progress: true
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                config:
-                    - {tag: 'alpine:edge', platforms: ['amd', 'arm']}
-                    - {tag: 'alpine:busybox-edge', platforms: ['amd', 'arm']}
-                    - {tag: 'arch:latest', platforms: ['amd']}
-                    - {tag: 'debian:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'fedora:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'opensuse:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'ubuntu:devel', platforms: ['amd', 'arm']}
-                    - {tag: 'ubuntu:rolling', platforms: ['amd', 'arm']}
-                    - {tag: 'void:latest', platforms: ['amd', 'arm']}
-        steps:
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v4
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
             - name: Create and Push Multi-Arch Manifest
+              if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
               run: |
                   tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
                   images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"


### PR DESCRIPTION
Tag the image immediately after it is built.

When an image failed to build (for example, due to a regression in a rolling distribution), the tagging step was not run.

Fixes: https://github.com/dracut-ng/dracut/issues/2589

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
