### PR TITLE
ci(fedora): fix persistent GPG/wrong key error for the Cisco OpenH264

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -27,6 +27,9 @@ ARG DISTRIBUTION
 # prefer running tests with xfs
 ENV TEST_FSTYPE=xfs
 
+RUN \
+dnf upgrade --refresh
+
 # btrfs kernel module is not available on CentOS
 RUN \
 if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \


### PR DESCRIPTION
Fix for the following package installation error

```
OpenPGP check for package "openh264" from repo "fedora-cisco-openh264" has failed

```

See recent failures at https://github.com/dracut-ng/dracut/actions/workflows/container-extra.yml

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
