### PR TITLE
fix(devicetree-firmware): Include some more qcom firmwares with --no-hostonly

### DIFF
--- a/modules.d/70devicetree-firmware/module-setup.sh
+++ b/modules.d/70devicetree-firmware/module-setup.sh
@@ -46,10 +46,10 @@ install_hostonly() {
 # generic install (hostonly / generic use completely different approaches)
 install_generic() {
     local _fw_files=()
-    # ATM only qcom WoA laptops need this
-    for _soc in qcom/sc8280xp qcom/x1e80100; do
-        # shellcheck disable=SC2154 # fw_dir is set by dracut.sh
-        for _fwdir in $fw_dir; do
+    # shellcheck disable=SC2154 # fw_dir is set by dracut.sh
+    for _fwdir in $fw_dir; do
+        # add laptop model specific firmwares for qcom WoA laptops
+        for _soc in qcom/sc8280xp qcom/x1e80100; do
             # add '*' after mbn, elf for .gz, etc. compression
             for _fw in "$_fwdir/$_soc"/*/*/*.mbn* "$_fwdir/$_soc"/*/*/*.elf*; do
                 [ -f "$_fw" ] || continue

--- a/modules.d/70devicetree-firmware/module-setup.sh
+++ b/modules.d/70devicetree-firmware/module-setup.sh
@@ -57,6 +57,12 @@ install_generic() {
                 _fw_files+=("$_fw")
             done
         done
+        # add soc specific firmwares needed to boot some qcom boards
+        for _fw in "$_fwdir/qcom"/*/qupv3fw.elf*; do
+            [ -f "$_fw" ] || continue
+            _fw=${_fw#"${dracutsysrootdir-}"}
+            _fw_files+=("$_fw")
+        done
     done
     ((${#_fw_files[@]} > 0)) && inst_multiple -o "${_fw_files[@]}"
 }

--- a/modules.d/70devicetree-firmware/module-setup.sh
+++ b/modules.d/70devicetree-firmware/module-setup.sh
@@ -49,7 +49,7 @@ install_generic() {
     # shellcheck disable=SC2154 # fw_dir is set by dracut.sh
     for _fwdir in $fw_dir; do
         # add laptop model specific firmwares for qcom WoA laptops
-        for _soc in qcom/sc8280xp qcom/x1e80100; do
+        for _soc in qcom/sc8280xp qcom/x1e80100 qcom/glymur; do
             # add '*' after mbn, elf for .gz, etc. compression
             for _fw in "$_fwdir/$_soc"/*/*/*.mbn* "$_fwdir/$_soc"/*/*/*.elf*; do
                 [ -f "$_fw" ] || continue


### PR DESCRIPTION
This pull-request extends `modules.d/70devicetree-firmware/module-setup.sh` : `install_generic()` to include some extra qcom firmwares in a generic initramfs:

1. Include some soc specific firmwares for the qcom-geni-se driver
2. Add ~$fw_dir`/qcom/glymur to the list of directories to check for Qualcomm WoA laptop model specific firmware.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2487066

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
