### PR TITLE
fix(base): fix shell fallback when shell-interpreter is not included

### DIFF
--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -61,7 +61,7 @@ install() {
     ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
 
     # fallback when shell-interpreter is not included
-    [ ! -e "${initdir}/bin/sh" ] && inst_simple "${initdir}/bin/sh" "/bin/sh"
+    [ ! -e "${initdir}/bin/sh" ] && inst "/bin/sh"
 
     # add common users in /etc/passwd, it will be used by nfs/ssh currently
     # use password for hostonly images to facilitate secure sulogin in emergency console


### PR DESCRIPTION
## Problem

Commit 7f13ea21 ("fix(base): fallback when shell-interpreter is not included") added a fallback in the base module to install a shell when the (optional) shell-interpreter module is not included (e.g. `dracut -m ...`):

```sh
[ ! -e "${initdir}/bin/sh" ] && inst_simple "${initdir}/bin/sh" "/bin/sh"
```

The source path points inside the not-yet-populated initdir. `inst_simple()` checks that the source exists (`[[ -e ... ]] || return 1`), and `${initdir}/bin/sh` can never exist at that point — its absence is exactly the condition the guard tests for. The line therefore always fails silently and the fallback never fires.

## Fix

Install the host `/bin/sh` with plain `inst()`. `dracut-install` resolves the symlink chain (installing the real binary, e.g. `/usr/bin/bash`, plus the `usr/bin/sh -> bash` link) and, because `inst()` enables dependency resolution, the shell's shared libraries are installed too — so the image gets a working shell rather than a dangling symlink.

Note: in common configurations the bug is currently masked, because installing any `#!/bin/sh` script via `inst_script()`/`inst_hook()` makes dracut-install pull in the script's interpreter automatically (see `resolve_deps()` in dracut-install.c). The fallback only becomes load-bearing in images that install no shell scripts at all (or with dependency resolution disabled) — precisely the minimal `-m` image scenario the original commit targeted.

## Testing

- Reproduced with an empty-initdir harness invoking the same functions as the module: the old line returns 1 and installs nothing; the new line installs `bin/sh -> bash`, `/bin/bash` and its library dependencies (libc, libtinfo, ld-linux). The installed shell executes correctly in a chroot.
- Regression: `./dracut.sh -m "base" --no-kernel` on Fedora 44 produces an image with a working `/bin/sh` before and after the change.
- `shellcheck modules.d/80base/module-setup.sh` clean.

Fixes: 7f13ea21 ("fix(base): fallback when shell-interpreter is not included")
