### PR TITLE
fix(fs-lib): append root fstab entry only when missing

### DIFF
--- a/modules.d/70fs-lib/fs-lib.sh
+++ b/modules.d/70fs-lib/fs-lib.sh
@@ -244,10 +244,8 @@ write_fs_tab() {
         fi
     fi
 
-    if grep -q "$_root /sysroot" /etc/fstab; then
+    if ! grep -q "$_root /sysroot" /etc/fstab; then
         echo "$_root /sysroot $_rootfstype $_rootflags $_fspassno 0" >> /etc/fstab
-    else
-        return
     fi
 
     if type systemctl > /dev/null 2> /dev/null; then


### PR DESCRIPTION
## Problem

Commit b12f8188 ("feat(nbd): support ipv6 link local nbds") changed the previously unconditional append in `write_fs_tab()` into a conditional — to avoid duplicate entries — but inverted the test:

```sh
if grep -q "$_root /sysroot" /etc/fstab; then
    echo "$_root /sysroot ..." >> /etc/fstab
else
    return
fi
```

As a result:

- **Normal case** (entry absent): the function returns early and the `/sysroot` entry is *never* added to the initramfs fstab.
- **Already-present case** (e.g. a iscsi/nbd hook runs twice): the entry is appended *again*, creating a duplicate.

Callers in the iscsi and nbd modules (`iscsiroot.sh`, `parse-iscsiroot.sh`, `nbdroot.sh`) rely on `write_fs_tab()` to record the root filesystem with the resolved rootfstype/rootflags and to trigger `daemon-reload` + `initrd-root-fs.target`.

## Fix

Negate the test so the entry is appended exactly when it is missing, and drop the now-pointless `else return`. This preserves the original de-duplication intent of b12f8188.

## Testing

Sandboxed harness executing the real `write_fs_tab()` (old from `git show HEAD:`, new from the working tree), with `/etc/fstab` repointed to a scratch file:

| case | before | after |
|---|---|---|
| entry missing | nothing written | one correct entry (`auto ro,x-initrd.mount 0 0`) |
| entry pre-seeded | duplicate appended | still exactly one entry |
| `rw` on cmdline | — | `ro,x-initrd.mount,rw` |

`shellcheck modules.d/70fs-lib/fs-lib.sh` clean.

Fixes: b12f8188 ("feat(nbd): support ipv6 link local nbds")
