### PR TITLE
fix(squash-lib): mirror host merged-usr symlinks in the squash loader

### DIFF
--- a/modules.d/88squash-lib/module-setup.sh
+++ b/modules.d/88squash-lib/module-setup.sh
@@ -42,7 +42,18 @@ squash_install() {
     # Create mount points for squash loader and basic directories
     mkdir -p "$initdir"/squash
     for _dir in squash usr/bin usr/sbin usr/lib; do
-        mkdir -p "$squashdir/$_dir"
+        if [[ -L ${dracutsysrootdir-}/$_dir ]]; then
+            # the host directory is a symlink (e.g. /usr/sbin -> bin on
+            # merged-usr systems); replicate the same symlink in the
+            # loader, otherwise tools installed into one merged tree
+            # (e.g. sh in usr/sbin) are not reachable from the other
+            # (/usr/bin/sh). The target text is copied from the host so
+            # that the link is valid both at boot time and while the
+            # loader directory is still being populated.
+            ln -sfn "$(readlink "${dracutsysrootdir-}/$_dir")" "$squashdir/$_dir"
+        else
+            mkdir -p "$squashdir/$_dir"
+        fi
         [[ $_dir == usr/* ]] && ln_r "/$_dir" "${_dir#usr}"
     done
 


### PR DESCRIPTION
## Problem

The squash loader (squash-lib) assembles its own root directory and creates `usr/bin`, `usr/sbin` and `usr/lib` as plain directories, only symlinking the top-level `bin`/`sbin`/`lib` to their usr counterparts:

```bash
for _dir in squash usr/bin usr/sbin usr/lib; do
    mkdir -p "$squashdir/$_dir"
    [[ $_dir == usr/* ]] && ln_r "/$_dir" "${_dir#usr}"
done
```

On merged-usr hosts where `/usr/sbin` itself is a symlink (`/usr/sbin -> bin`, e.g. Fedora 42+), binaries resolved on the host's unified tree are installed into only one of the two split trees in the loader. In particular the busybox module creates its applet links with a shell-side `ln_r /usr/bin/busybox "$_path"` (no symlink resolution by dracut-install in that path), so `sh` physically lands in the loader's real `usr/sbin/` directory while `/bin/sh` == `/usr/bin/sh` stays missing. The kernel then cannot execute the shebang of `init-squash.sh`:

```
Run /init as init process
Failed to execute /init (error -2)
```

This is what breaks the kdump squashfs image on Fedora 42+ in #2454. The main initramfs path does not hit this because `create_directories()` in dracut.sh mirrors the host layout (`if [ -L "/$d" ]` → install as symlink).

## Fix

Mirror the host layout in `squash_install()`: if the host directory is a symlink, replicate the same symlink in the loader directory; otherwise create a real directory as before. Binaries installed to either merged tree (`usr/sbin/foo` or `usr/bin/foo`) then always land in the single shared tree, matching host semantics.

Root-cause alternative to #2455: instead of special-casing the busybox `sh` symlink, this fixes the directory structure itself, so it covers every binary — not just `sh` — for both the busybox and the non-busybox loader paths.

## Testing

Reproduced the exact failure from #2454 and verified the fix on two Fedora 44 systems (qemu/KVM guest boot on real hardware, busybox package installed, squashfs handler available, `PATH` with `/usr/sbin` first as in the kdump build environment):

| check | before | after |
|---|---|---|
| loader layout | `usr/sbin` real dir, `sh -> ../bin/busybox` stranded there, **`usr/bin/sh` absent** | `usr/sbin -> bin`, `usr/bin/sh -> busybox` |
| exec test (`chroot` into extracted loader tree — the kernel's ENOENT path) | `failed to run command '/init': No such file or directory` (**error -2**) | `/bin/sh` executes (exit 0) |
| qemu boot of the image | `Run /init as init process` → **`Failed to execute /init (error -2)`** | `/init` executes, `squashfs` mounts, `switch_root` into the inner systemd initramfs, boot proceeds to `initrd-switch-root.target` (ends there only because the synthetic test image has no real `root=` device) |

Boot logs were captured from the VM serial console for both runs.

`shellcheck modules.d/88squash-lib/module-setup.sh` clean.

Fixes: https://github.com/dracut-ng/dracut/issues/2454
