### PR TITLE
fix(network-legacy): write fallback teamd config to /etc/teamd

### DIFF
--- a/modules.d/35network-legacy/parse-team.sh
+++ b/modules.d/35network-legacy/parse-team.sh
@@ -61,6 +61,6 @@ for team in $(getargs team); do
     if ! [ -e /etc/teamd/"${teammaster}".conf ]; then
         warn "Team master $teammaster specified, but no /etc/teamd/$teammaster.conf present. Using $teamrunner."
         mkdir -p /etc/teamd
-        printf -- "%s" "{\"runner\": {\"name\": \"$teamrunner\"}, \"link_watch\": {\"name\": \"ethtool\"}}" > "/tmp/${teammaster}.conf"
+        printf -- "%s" "{\"runner\": {\"name\": \"$teamrunner\"}, \"link_watch\": {\"name\": \"ethtool\"}}" > "/etc/teamd/${teammaster}.conf"
     fi
 done


### PR DESCRIPTION
## Problem

Booting with `team=<master>:<slaves>[:<runner>]` on the kernel command line and **no host ifcfg `TEAM_CONFIG`** relies on the fallback configuration that `modules.d/35network-legacy/parse-team.sh` generates. Commit e4483e59 ("Configure the runner for team interfaces") changed the output path of that generated config from `/etc/teamd/<master>.conf` to `/tmp/<master>.conf` — but the consumer was never updated: `ifup.sh:380` still launches

```
teamd -d -U -n -N -t <master> -f /etc/teamd/<master>.conf
```

So **the fallback config is written to a location nobody reads**. With a real `teamd` this fails as:

```
Failed to get absolute path of "/etc/teamd/team0.conf": No such file or directory
```

→ `teamd` exits, the team master is never created, and **network boot over a team is broken** for the cmdline-only (no host config) case. Setups whose host `TEAM_CONFIG` was installed into `/etc/teamd/` at image build time (`module-setup.sh`) are unaffected — which is presumably why this went unnoticed since 2020.

## Fix

Restore writing the fallback config to `/etc/teamd/<master>.conf`, matching the consumer in `ifup.sh` and the pre-e4483e59 behavior. One line changed. The `/tmp/team.<master>.info` / `/tmp/team.<master>.up` state files correctly stay in `/tmp` (they are consumed by `ifup.sh` directly).

## Verification

No CI coverage for this path (the network-legacy BOND/BRIDGE/VLAN tests covering team were removed in 88406ce2 as always-skipped), so verified manually end-to-end with the **real** `parse-team.sh` and the **real** `teamd` 1.32 on Fedora 44 in private mount/network namespaces:

```
===== BEFORE (current master) =====
WARN: Team master team0 specified ... Using activebackup.
--- teamd invocation (same flags as ifup.sh:380):
>>> teamd DEAD, team0 ABSENT. teamd log:
Failed to get absolute path of "/etc/teamd/team0.conf": No such file or directory

===== AFTER (this PR) =====
WARN: Team master team0 specified ... Using activebackup.
>>> teamd RUNNING, team0 device EXISTS. teamdctl state:
setup:
  runner: activebackup
4: team0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN ...
```

(team0 is `DOWN` only because no ports are enslaved in this minimal test — `ifup.sh` enslaves the working slaves right after starting teamd. The failing part — loading the config and creating the device with the right runner — works.)

The generated JSON `{"runner": {"name": "activebackup"}, "link_watch": {"name": "ethtool"}}` is identical in both runs; only its location changes.
