### PR TITLE
fix(tests): delete /run/initramfs/dracut.conf.d during cleanup

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -433,6 +433,13 @@ print_test_result() {
     fi
 }
 
+# cleanup commands shared between all tests, run after test_cleanup
+test_common_cleanup() {
+    rm -fr /run/initramfs/dracut.conf.d
+    rm -fr -- "$TESTDIR"
+    rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
+}
+
 while (($# > 0)); do
     case $1 in
         --run)
@@ -450,8 +457,7 @@ while (($# > 0)); do
         --clean)
             echo "TEST CLEANUP: $TEST_DESCRIPTION"
             test_cleanup
-            rm -fr -- "$TESTDIR"
-            rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
+            test_common_cleanup
             exit $?
             ;;
         --all)
@@ -472,16 +478,14 @@ while (($# > 0)); do
                     test_setup
                     test_run
                     test_cleanup
-                    rm -fr -- "$TESTDIR"
-                    rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
+                    test_common_cleanup
                 ) 2>&1 | "$tee_command" "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
             else
                 (
                     test_setup
                     test_run
                     test_cleanup
-                    rm -fr -- "$TESTDIR"
-                    rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
+                    test_common_cleanup
                 ) > test${TEST_RUN_ID:+-$TEST_RUN_ID}.log 2>&1
             fi
             set +o pipefail


### PR DESCRIPTION
Some tests write config fragments to /run/initramfs/dracut.conf.d, which may break following tests. For an example, run (without this commit):

```
TESTS="12 13" ./test/test.sh debian
```

The result is that test 13 tries to run `ukify`, which it's not supposed to, and fails. The reason is that test 12 left the config fragment `10-uki-virt.conf` behind. Running each test individually (like happens in CI) works, because that way each test gets a fresh container with clean `/run`.

Move the commands that always run after test_cleanup to a function to avoid triplicating them all.

Found while working on #2588.

### Example error

```
TEST: initramfs created from sysroot   [STARTED]
Calling dracut --confdir /var/tmp/dracut-test.nGChjW/dracut.conf.d --add-confdir test --tmpdir /var/tmp/dracut-test.nGChjW/initrd /var/tmp/dracut-test.nGChjW/initramfs.testing
WARNING: cannot read detailed chunk info, per-device usage will not be shown, run as root
Traceback (most recent call last):
  File "/usr/bin/ukify", line 2246, in <module>
    main()
    ~~~~^^
  File "/usr/bin/ukify", line 2235, in main
    make_uki(opts)
    ~~~~~~~~^^^^^^
  File "/usr/bin/ukify", line 1317, in make_uki
    pe_add_sections(uki, unsigned_output)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/ukify", line 939, in pe_add_sections
    data = section.content.read_bytes()
  File "/usr/lib/python3.13/pathlib/_abc.py", line 625, in read_bytes
    with self.open(mode='rb') as f:
         ~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/pathlib/_local.py", line 539, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '/var/tmp/dracut-test.nGChjW/sysroot'
dracut[F]: *** Creating UEFI image file '/var/tmp/dracut-test.nGChjW/initramfs.testing' failed ***
Not removing /var/tmp/dracut-test.nGChjW/initrd/dracut.dg6qnyc.
TEST: initramfs created from sysroot   [FAILED]                                                                        
```

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
