### PR TITLE
ci: unskipp passing networking tests on Debian

### DIFF
--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -48,9 +48,6 @@ jobs:
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     - container: fedora:rawhide
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    # https://github.com/dracut-ng/dracut/issues/1988
-                    - container: debian:sid
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     # In Debian/Ubuntu both chrony and systemd-timesyncd provide
                     # the virtual package time-daemon, so systemd-timesyncd
                     # would have to be removed, breaking test 41.

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -62,9 +62,6 @@ jobs:
                     # intentionally skipped
                     - container: centos:latest
                       test: "41"
-                    # https://github.com/dracut-ng/dracut/issues/1988
-                    - container: debian:sid
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     # TEST-45-SYSTEMD-IMPORT requires systemd >= v258
                     - container: centos:latest
                       test: "45"


### PR DESCRIPTION
https://github.com/dracut-ng/dracut/issues/1988 is no longer failing.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
