### PR TITLE
fix(zipl): strip /dev/ prefix for the KERNEL udev match

### DIFF
--- a/modules.d/73zipl/parse-zipl.sh
+++ b/modules.d/73zipl/parse-zipl.sh
@@ -36,7 +36,7 @@ if [ -n "$zipl_arg" ]; then
             ;;
         /dev/*)
             zipl_env="KERNEL"
-            zipl_val=${zipl_arg}
+            zipl_val=${zipl_arg#/dev/}
             ;;
     esac
     if [ "$zipl_env" ]; then


### PR DESCRIPTION
## Problem

The primary documented form of `rd.zipl` is `rd.zipl=<path to blockdevice>` (dracut.cmdline.7). For it, `modules.d/73zipl/parse-zipl.sh` generates a udev rule with the match value set to the **full path**:

```
ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="/dev/dasda1", ENV{SYSTEMD_READY}!="0", RUN+="/sbin/initqueue --settled --onetime --unique --name install_zipl_cmdline ..."
```

But udev `KERNEL==` matches the kernel device name (`dasda1`), never a `/dev/...` path — so **this rule can never fire**. `/tmp/install.zipl.cmdline-done` is never created, `wait-zipl-conf.sh` never becomes true, the initqueue spins until the boot timeout, and the system drops into the *emergency shell* instead of booting with the zipl-provided cmdline.

The sibling cases handle prefixes correctly: `/dev/mapper/*` strips it (`ENV{DM_NAME}=="klk"`), `/dev/disk/by-*` strips it (`SYMLINK=="disk/by-..."`) — only the plain `/dev/*` branch passes the path verbatim. Note that merged PR #2316 fixed the `LABEL/UUID/PARTLABEL/PARTUUID` variants of this same file (75731188); the `/dev/*` case has the residual variant.

## Fix

Strip the `/dev/` prefix for the KERNEL match: `zipl_val=${zipl_arg#/dev/}`. One line plus a comment, matching the existing pattern used by the other branches. No behavioral change for the other four input forms.

## Verification

Since zipl is s390x-specific there is no easy full-boot CI coverage for this path; the verification is by construction + evaluation with the real udev evaluator:

1. **Rule text, all forms** — running the real parse-zipl.sh (sandboxed, stubbed `getarg`/`label_uuid_to_dev`) for every documented form:

   | input | rule before | rule after |
   |---|---|---|
   | `/dev/dasda1` | `KERNEL=="/dev/dasda1"` | `KERNEL=="dasda1"` |
   | `/dev/mapper/klk` | `ENV{DM_NAME}=="klk"` | identical |
   | `/dev/disk/by-path/...` | `SYMLINK=="disk/by-path/..."` | identical |
   | `UUID=abc` | `ENV{ID_FS_UUID}=="abc"` | identical |

2. **Real udev match** — evaluating the two rule shapes with `udevadm test` against a real block device on Fedora 44:

   ```
   device: /dev/nvme0n1 (kernel name: nvme0n1)
   BEFORE rule (KERNEL=="/dev/nvme0n1"):  0 matches   <- never fires, the bug
   AFTER  rule (KERNEL=="nvme0n1"):       1 match
   ```

`shellcheck modules.d/73zipl/parse-zipl.sh` clean.