### PR TITLE
fix(tests): delete /run/initramfs/dracut.conf.d only in container

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -435,9 +435,12 @@ print_test_result() {
 
 # cleanup commands shared between all tests, run after test_cleanup
 test_common_cleanup() {
-    rm -fr /run/initramfs/dracut.conf.d
     rm -fr -- "$TESTDIR"
     rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
+    # clean /run only if running in test container, not on "make clean"
+    if command -v systemd-detect-virt > /dev/null && systemd-detect-virt -c &> /dev/null; then
+        rm -fr /run/initramfs/dracut.conf.d
+    fi
 }
 
 while (($# > 0)); do


### PR DESCRIPTION
Cleanup is not exclusively called in the test containers, but also when manually running `make clean`. In most cases trying to delete `/run/initramfs/dracut.conf.d` outside the test container will cause pointless errors, should someone run `make clean` as root it might cause damage.

I missed that in #2608, sorry about the noise!

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
