### PR TITLE
fix(dracut): support dracutsysrootdir in create_directories

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2647,7 +2647,7 @@ create_directories() {
     for d in "$@"; do
         d=${d#/}
         [[ -e "${initdir}${prefix}/$d" ]] && continue
-        if [ -L "/$d" ]; then
+        if [ -L "${dracutsysrootdir-}/$d" ]; then
             inst_symlink "/$d" "${prefix}/$d"
         else
             # shellcheck disable=SC2174


### PR DESCRIPTION
`create_directories` should check the directory in `dracutsysrootdir` and not on the host system.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
