### PR TITLE
style(ci): use multiline block format

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -37,16 +37,33 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - platform: linux/amd64
+                      runner: ubuntu-24.04
+                      tag: amd
+                    - platform: linux/arm64
+                      runner: ubuntu-24.04-arm
+                      tag: arm
                 config:
-                    - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:latest', registry: 'mcr.microsoft.com'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:arm64-openrc', option: 'arm64-openrc'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
+                    - dockerfile: Dockerfile-azurelinux
+                      tag: azurelinux:latest
+                      registry: mcr.microsoft.com
+                    - dockerfile: Dockerfile-fedora
+                      tag: centos:latest
+                      registry: quay.io/centos
+                    - dockerfile: Dockerfile-debian
+                      tag: debian:sid
+                    - dockerfile: Dockerfile-fedora
+                      tag: fedora:rawhide
+                      registry: registry.fedoraproject.org
+                    - dockerfile: Dockerfile-gentoo
+                      tag: gentoo:amd64-openrc
+                      option: amd64-openrc
+                    - dockerfile: Dockerfile-gentoo
+                      tag: gentoo:arm64-openrc
+                      option: arm64-openrc
+                    - dockerfile: Dockerfile-gentoo
+                      tag: gentoo:latest
+                      option: systemd
                 exclude:
                     # arch container does not support arm
                     - config: {tag: 'arch:latest'}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,18 +34,32 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - platform: linux/amd64
+                      runner: ubuntu-24.04
+                      tag: amd
+                    - platform: linux/arm64
+                      runner: ubuntu-24.04-arm
+                      tag: arm
                 config:
-                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
-                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:busybox-edge', option: 'busybox'}
-                    - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'debian:latest'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
-                    - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
-                    - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
+                    - dockerfile: Dockerfile-alpine
+                      tag: alpine:edge
+                    - dockerfile: Dockerfile-alpine
+                      tag: alpine:busybox-edge
+                      option: busybox
+                    - dockerfile: Dockerfile-arch
+                      tag: arch:latest
+                    - dockerfile: Dockerfile-debian
+                      tag: debian:latest
+                    - dockerfile: Dockerfile-fedora
+                      tag: fedora:latest
+                    - dockerfile: Dockerfile-opensuse
+                      tag: opensuse:latest
+                    - dockerfile: Dockerfile-debian
+                      tag: ubuntu:devel
+                    - dockerfile: Dockerfile-debian
+                      tag: ubuntu:rolling
+                    - dockerfile: Dockerfile-void
+                      tag: void:latest
                 exclude:
                     # arch container does not support arm
                     - config: {tag: 'arch:latest'}

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 40
                 container:
                     - debian:latest
                     - debian:sid
@@ -70,7 +74,9 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
                 container:
                     - alpine:edge
                     - arch:latest
@@ -117,7 +123,9 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 40
                 container:
                     - gentoo:arm64-openrc
                 test:

--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 40
                 container:
                     - ubuntu:rolling
                 test:

--- a/.github/workflows/daily-nbd.yml
+++ b/.github/workflows/daily-nbd.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 40
                 container:
                     - arch:latest
                     - debian:latest

--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -29,8 +29,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 15}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 15
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 60
                 network:
                     - network-legacy
                 container:

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 15}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 15
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 60
                 container:
                     - arch:latest
                     - debian:latest

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 15}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 15
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 60
                 container:
                     - ubuntu:rolling
                 test:

--- a/.github/workflows/daily-systemd-networkd.yml
+++ b/.github/workflows/daily-systemd-networkd.yml
@@ -29,8 +29,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 20}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 20
                 network:
                     - systemd-networkd
                 container:

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 20}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 20
                 container:
                     - arch:latest
                     - azurelinux:latest

--- a/.github/workflows/daily-zfs.yml
+++ b/.github/workflows/daily-zfs.yml
@@ -26,8 +26,12 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
+                    - runner: ubuntu-24.04
+                      tag: amd
+                      timeout: 10
+                    - runner: ubuntu-24.04-arm
+                      tag: arm
+                      timeout: 40
                 container:
                     - void:latest
                 test:


### PR DESCRIPTION
Convert inline YAML flow objects with three or more entries to multiline block syntax across the CI workflow files to improve readability and ease of extensibitity.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
