### PR TITLE
fix(dracut-install): bounds-check RUNPATH walk and ELF string derefs

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -865,6 +865,17 @@ static const char *elf_sect_name(const char *shstrtab, size_t shstrtab_len, uint
         return shstrtab + name_off;
 }
 
+/* Return a pointer to the NUL-terminated string at the given offset within
+   the mapped file, or NULL if the offset is out of bounds or the string
+   would not be NUL-terminated within the map. */
+static const char *elf_map_string(const char *map, size_t src_len, size_t offset)
+{
+        if (offset >= src_len || !memchr(map + offset, '\0', src_len - offset))
+                return NULL;
+
+        return map + offset;
+}
+
 /* Get a pointer to the ELF header map's section header string table, where B is
    64 or 32 bit. Sanity checks the ELF structure to avoid crashes. */
 #define PARSE_ELF_START(B, map) \
@@ -906,7 +917,12 @@ static const char *elf_sect_name(const char *shstrtab, size_t shstrtab_len, uint
                         continue; \
 \
                 Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
+                if ((char *)dyn < (char *)map || (char *)dyn > (char *)map + src_len) \
+                        break; \
+\
                 for (Elf##B##_Dyn *d = dyn; ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
+                        if ((char *)d < (char *)map || (char *)d + sizeof(Elf##B##_Dyn) > (char *)map + src_len) \
+                                break; \
                         if (ELF_BYTESWAP(B, d->d_tag) == DT_RUNPATH) \
                                 seen_runpath = true; /* RUNPATH has precedence over RPATH. */ \
                         else if (seen_runpath || ELF_BYTESWAP(B, d->d_tag) != DT_RPATH) \
@@ -915,7 +931,10 @@ static const char *elf_sect_name(const char *shstrtab, size_t shstrtab_len, uint
                         if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                                 break; \
 \
-                        char *runpath = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val); \
+                        const char *runpath = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val)); \
+                        if (!runpath) \
+                                break; \
+\
                         _cleanup_free_ char *expanded = expand_runpath(runpath, src, match64); \
                         if (!expanded) \
                                 continue; \
@@ -1072,11 +1091,9 @@ skip:
                         if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                                 break; \
 \
-                        soname = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val); \
-                        if ((char *)soname < (char *)map || (char *)soname > (char *)map + src_len) { \
-                                soname = NULL; \
+                        soname = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val)); \
+                        if (!soname) \
                                 break; \
-                        } \
                 } \
         } \
 \
@@ -1129,8 +1146,8 @@ skip:
                         if (ELF_BYTESWAP(32, phdr->p_type) != PT_INTERP) \
                                 continue; \
 \
-                        const char *interpreter = (const char *)map + ELF_BYTESWAP(B, phdr->p_offset); \
-                        if (interpreter < (char *)map || interpreter > (char *)map + src_len) \
+                        const char *interpreter = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, phdr->p_offset)); \
+                        if (!interpreter) \
                                 break; \
                         if (hashmap_get(pdeps, interpreter)) \
                                 continue; \
@@ -1164,8 +1181,8 @@ skip:
                         if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                                 break; \
 \
-                        const char *soname = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val); \
-                        if ((char *)soname < (char *)map || (char *)soname > (char *)map + src_len) \
+                        const char *soname = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val)); \
+                        if (!soname) \
                                 break; \
                         if (hashmap_get(pdeps, soname)) \
                                 continue; \

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -854,6 +854,17 @@ oom:
    that is expanded using the C compiler rather than the preprocessor. */
 #define ELF_BYTESWAP(SIZE, value) (ehdr->e_ident[EI_DATA] == ELFDATA2MSB ? be##SIZE##toh(value) : le##SIZE##toh(value))
 
+/* Safely look up a section name in a bounds-checked section header string
+   table. Returns NULL if the name offset is out of bounds or the name is
+   not NUL-terminated within the table. */
+static const char *elf_sect_name(const char *shstrtab, size_t shstrtab_len, uint32_t name_off)
+{
+        if (name_off >= shstrtab_len || !memchr(shstrtab + name_off, '\0', shstrtab_len - name_off))
+                return NULL;
+
+        return shstrtab + name_off;
+}
+
 /* Get a pointer to the ELF header map's section header string table, where B is
    64 or 32 bit. Sanity checks the ELF structure to avoid crashes. */
 #define PARSE_ELF_START(B, map) \
@@ -864,8 +875,23 @@ oom:
             ELF_BYTESWAP(16, ehdr->e_shstrndx) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                 break; \
 \
+        /* The whole section header table must fit into the mapped file, \
+           otherwise indexing into it could read past the mapping. */ \
+        if ((size_t)ELF_BYTESWAP(16, ehdr->e_shnum) > \
+            (src_len - (size_t)ELF_BYTESWAP(B, ehdr->e_shoff)) / sizeof(Elf##B##_Shdr)) \
+                break; \
+\
         Elf##B##_Shdr *shdr = (Elf##B##_Shdr *)((char *)map + ELF_BYTESWAP(B, ehdr->e_shoff)); \
-        const char *shstrtab = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(16, ehdr->e_shstrndx)].sh_offset);
+        Elf##B##_Shdr *shstrshdr = &shdr[ELF_BYTESWAP(16, ehdr->e_shstrndx)]; \
+\
+        /* The section header string table must fit into the mapped file, \
+           otherwise comparing section names could read past the mapping. */ \
+        size_t shstrtab_len = ELF_BYTESWAP(B, shstrshdr->sh_size); \
+        if (ELF_BYTESWAP(B, shstrshdr->sh_offset) > src_len || \
+            shstrtab_len > src_len - (size_t)ELF_BYTESWAP(B, shstrshdr->sh_offset)) \
+                break; \
+\
+        const char *shstrtab = (char *)map + ELF_BYTESWAP(B, shstrshdr->sh_offset);
 
 /* Expand the R(UN)PATH of the ELF header map and search it for a library
    matching soname and match64/match32. map must point to the same header as
@@ -875,7 +901,8 @@ oom:
         bool seen_runpath = false; \
 \
         for (size_t i = 0; i < ELF_BYTESWAP(16, ehdr->e_shnum); i++) { \
-                if (strcmp(&shstrtab[ELF_BYTESWAP(32, shdr[i].sh_name)], ".dynamic") != 0) \
+                const char *sect_name = elf_sect_name(shstrtab, shstrtab_len, ELF_BYTESWAP(32, shdr[i].sh_name)); \
+                if (!sect_name || strcmp(sect_name, ".dynamic") != 0) \
                         continue; \
 \
                 Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
@@ -884,6 +911,9 @@ oom:
                                 seen_runpath = true; /* RUNPATH has precedence over RPATH. */ \
                         else if (seen_runpath || ELF_BYTESWAP(B, d->d_tag) != DT_RPATH) \
                                 continue; \
+\
+                        if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
+                                break; \
 \
                         char *runpath = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val); \
                         _cleanup_free_ char *expanded = expand_runpath(runpath, src, match64); \
@@ -1025,7 +1055,8 @@ skip:
         for (size_t i = 0; !soname && i < ELF_BYTESWAP(16, ehdr->e_shnum); i++) { \
                 if ((char*)&shdr[i] < (char*)map || (char*)&shdr[i] + sizeof(Elf##B##_Shdr) > (char*)map + src_len) \
                         break; \
-                if (strcmp(&shstrtab[ELF_BYTESWAP(32, shdr[i].sh_name)], ".dynamic") != 0) \
+                const char *sect_name = elf_sect_name(shstrtab, shstrtab_len, ELF_BYTESWAP(32, shdr[i].sh_name)); \
+                if (!sect_name || strcmp(sect_name, ".dynamic") != 0) \
                         continue; \
 \
                 Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
@@ -1038,6 +1069,9 @@ skip:
                         if (ELF_BYTESWAP(B, d->d_tag) != DT_SONAME) \
                                 continue; \
 \
+                        if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
+                                break; \
+\
                         soname = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val); \
                         if ((char *)soname < (char *)map || (char *)soname > (char *)map + src_len) { \
                                 soname = NULL; \
@@ -1049,7 +1083,8 @@ skip:
         for (size_t i = 0; i < ELF_BYTESWAP(16, ehdr->e_shnum); i++) { \
                 if ((char*)shdr + i * sizeof(Elf##B##_Shdr) > (char*)map + src_len) \
                         break; \
-                if (strcmp(&shstrtab[ELF_BYTESWAP(32, shdr[i].sh_name)], ".note.dlopen") != 0) \
+                const char *sect_name = elf_sect_name(shstrtab, shstrtab_len, ELF_BYTESWAP(32, shdr[i].sh_name)); \
+                if (!sect_name || strcmp(sect_name, ".note.dlopen") != 0) \
                         continue; \
 \
                 const char *note_offset = (char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset); \
@@ -1112,7 +1147,8 @@ skip:
         for (size_t i = 0; i < ELF_BYTESWAP(16, ehdr->e_shnum); i++) { \
                 if ((char*)&shdr[i] < (char*)map || (char*)&shdr[i] + sizeof(Elf##B##_Shdr) > (char*)map + src_len) \
                         break; \
-                if (strcmp(&shstrtab[ELF_BYTESWAP(32, shdr[i].sh_name)], ".dynamic") != 0) \
+                const char *sect_name = elf_sect_name(shstrtab, shstrtab_len, ELF_BYTESWAP(32, shdr[i].sh_name)); \
+                if (!sect_name || strcmp(sect_name, ".dynamic") != 0) \
                         continue; \
 \
                 Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
@@ -1124,6 +1160,9 @@ skip:
                                 break; \
                         if (ELF_BYTESWAP(B, d->d_tag) != DT_NEEDED) \
                                 continue; \
+\
+                        if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
+                                break; \
 \
                         const char *soname = (char *)map + ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val); \
                         if ((char *)soname < (char *)map || (char *)soname > (char *)map + src_len) \

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -916,13 +916,13 @@ static const char *elf_map_string(const char *map, size_t src_len, size_t offset
                 if (!sect_name || strcmp(sect_name, ".dynamic") != 0) \
                         continue; \
 \
-                Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
-                if ((char *)dyn < (char *)map || (char *)dyn > (char *)map + src_len) \
+                if (ELF_BYTESWAP(B, shdr[i].sh_offset) > src_len) \
                         break; \
+                Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
 \
-                for (Elf##B##_Dyn *d = dyn; ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
-                        if ((char *)d < (char *)map || (char *)d + sizeof(Elf##B##_Dyn) > (char *)map + src_len) \
-                                break; \
+                for (Elf##B##_Dyn *d = dyn; \
+                        (char *)d + sizeof(Elf##B##_Dyn) <= (char *)map + src_len && \
+                        ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
                         if (ELF_BYTESWAP(B, d->d_tag) == DT_RUNPATH) \
                                 seen_runpath = true; /* RUNPATH has precedence over RPATH. */ \
                         else if (seen_runpath || ELF_BYTESWAP(B, d->d_tag) != DT_RPATH) \
@@ -1078,13 +1078,13 @@ skip:
                 if (!sect_name || strcmp(sect_name, ".dynamic") != 0) \
                         continue; \
 \
-                Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
-                if ((char *)dyn < (char *)map || (char *)dyn > (char *)map + src_len) \
+                if (ELF_BYTESWAP(B, shdr[i].sh_offset) > src_len) \
                         break; \
+                Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
 \
-                for (Elf##B##_Dyn *d = dyn; !soname && ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
-                        if ((char *)d < (char *)map || (char *)d + sizeof(Elf##B##_Dyn) > (char *)map + src_len) \
-                                break; \
+                for (Elf##B##_Dyn *d = dyn; \
+                        !soname && (char *)d + sizeof(Elf##B##_Dyn) <= (char *)map + src_len && \
+                        ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
                         if (ELF_BYTESWAP(B, d->d_tag) != DT_SONAME) \
                                 continue; \
 \
@@ -1168,13 +1168,13 @@ skip:
                 if (!sect_name || strcmp(sect_name, ".dynamic") != 0) \
                         continue; \
 \
-                Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
-                if ((char *)dyn < (char *)map || (char *)dyn > (char *)map + src_len) \
+                if (ELF_BYTESWAP(B, shdr[i].sh_offset) > src_len) \
                         break; \
+                Elf##B##_Dyn *dyn = (Elf##B##_Dyn *)((char *)map + ELF_BYTESWAP(B, shdr[i].sh_offset)); \
 \
-                for (Elf##B##_Dyn *d = dyn; ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
-                        if ((char *)d < (char *)map || (char *)d + sizeof(Elf##B##_Dyn) > (char *)map + src_len) \
-                                break; \
+                for (Elf##B##_Dyn *d = dyn; \
+                        (char *)d + sizeof(Elf##B##_Dyn) <= (char *)map + src_len && \
+                        ELF_BYTESWAP(32, d->d_tag) != DT_NULL; d++) { \
                         if (ELF_BYTESWAP(B, d->d_tag) != DT_NEEDED) \
                                 continue; \
 \

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -931,7 +931,13 @@ static const char *elf_map_string(const char *map, size_t src_len, size_t offset
                         if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                                 break; \
 \
-                        const char *runpath = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val)); \
+                        /* Clamp both operands to the map so the offset addition cannot wrap. */ \
+                        size_t strtab_off = ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset); \
+                        if (strtab_off > src_len || \
+                            ELF_BYTESWAP(B, d->d_un.d_val) > src_len - strtab_off) \
+                                break; \
+\
+                        const char *runpath = elf_map_string((const char *)map, src_len, strtab_off + ELF_BYTESWAP(B, d->d_un.d_val)); \
                         if (!runpath) \
                                 break; \
 \
@@ -1091,7 +1097,13 @@ skip:
                         if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                                 break; \
 \
-                        soname = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val)); \
+                        /* Clamp both operands to the map so the offset addition cannot wrap. */ \
+                        size_t strtab_off = ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset); \
+                        if (strtab_off > src_len || \
+                            ELF_BYTESWAP(B, d->d_un.d_val) > src_len - strtab_off) \
+                                break; \
+\
+                        soname = elf_map_string((const char *)map, src_len, strtab_off + ELF_BYTESWAP(B, d->d_un.d_val)); \
                         if (!soname) \
                                 break; \
                 } \
@@ -1181,7 +1193,13 @@ skip:
                         if (ELF_BYTESWAP(32, shdr[i].sh_link) >= ELF_BYTESWAP(16, ehdr->e_shnum)) \
                                 break; \
 \
-                        const char *soname = elf_map_string((const char *)map, src_len, ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset) + ELF_BYTESWAP(B, d->d_un.d_val)); \
+                        /* Clamp both operands to the map so the offset addition cannot wrap. */ \
+                        size_t strtab_off = ELF_BYTESWAP(B, shdr[ELF_BYTESWAP(32, shdr[i].sh_link)].sh_offset); \
+                        if (strtab_off > src_len || \
+                            ELF_BYTESWAP(B, d->d_un.d_val) > src_len - strtab_off) \
+                                break; \
+\
+                        const char *soname = elf_map_string((const char *)map, src_len, strtab_off + ELF_BYTESWAP(B, d->d_un.d_val)); \
                         if (!soname) \
                                 break; \
                         if (hashmap_get(pdeps, soname)) \


### PR DESCRIPTION
**Stacked on #2615** (depends on its `PARSE_ELF_START` extent checks and `elf_sect_name` helper). Will be rebased after #2615 merges.

## Problem

`FIND_LIBRARY_RUNPATH_FOR_BITS` (in `src/install/dracut-install.c`) walks the ELF `.dynamic` section's `Elf_Dyn` array and pulls out the DT_RUNPATH / DT_RPATH strings to search for libraries. Unlike the sibling macros `RESOLVE_DEPS_NEEDED_FOR_BITS` and `RESOLVE_DEPS_DLOPEN_FOR_BITS`, this walk validates only `e_shoff`/`e_shstrndx` — the per-iteration pointers into the map are never bounds-checked. Additionally, in the interpreter/`DT_SONAME`/`DT_NEEDED` code paths the strings extracted with `(char *)map + shdr[i].sh_offset + d->d_un.d_val` are handed to `strlen`/`strdup`/`hashmap_get`/`expand_runpath`/`regexec` without verifying they are NUL-terminated within the mapped file (a malformed ELF reading past the end of the map can hang on a never-terminated `strcmp`/`strdup`).

Also found one off-by-boundary check in the interpreter path: `interpreter > (char *)map + src_len` accepts the pointer at exactly one-past-end (should be `>=`).

## Fix

- New shared helper `elf_map_string(map, src_len, offset)`: returns NULL if the offset is outside the map or the string there isn't NUL-terminated within the map. Used for the runpath string, interpreter string, DT_SONAME and DT_NEEDED strings.
- The RUNPATH walk now mirrors its siblings' per-iteration bounds checks on `dyn` and `d`.

## Verification

Crafted 3 malformed ELF64 inputs exercising each new check; ran the real `dracut-install -l` binary built before/after, and `valgrind` on the difference-maker:

| input | before | after |
|---|---|---|
| `H7A2`: DT_RPATH whose strtab pointer lands 4 bytes before map end, runpath not NUL-terminated | valgrind `Invalid read of size 1` → SIGSEGV | clean exit 0 (section rejected) |
| `H7B2`: PT_INTERP at exactly `src_len` one-past-end | no crash (never dereferenced) | clean exit 0 (no change needed⁠—it's never actually reached the new helper with that offset as a valid string; check now correctly excludes) |
| `H7C2`: PT_INTERP in-map but non-terminated | clean | clean exit 0 |

(The last two are safe in both versions only because no code path dereferences them — they're defensive/paranoia checks. The RUNPATH one is the reachable crash.)

**Regression control:** `-l` dependency resolution of `/bin/bash`, `/bin/ls`, and `/usr/bin/ssh` — byte-identical 33-entry file list before vs after. **H6 test set re-verified** — the 6 malformed ELFs from #2615's verification table still all exit cleanly.