### PR TITLE
perf(bluetooth): do not try to install 60-persistent-input.rules

### DIFF
--- a/modules.d/70bluetooth/module-setup.sh
+++ b/modules.d/70bluetooth/module-setup.sh
@@ -23,8 +23,7 @@ check() {
 
 # Module dependency requirements.
 depends() {
-    # This module has external dependencies on the systemd and dbus modules.
-    echo systemd dbus
+    echo dbus systemd-udevd
     # Return 0 to include the dependent modules in the initramfs.
     return 0
 }
@@ -80,7 +79,7 @@ install() {
             "${var_lib_files[@]#"${dracutsysrootdir-}"}"
     fi
 
-    inst_rules 69-btattach-bcm.rules 60-persistent-input.rules
+    inst_rules 69-btattach-bcm.rules
 
     sed -i -e \
         '/^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target\nAfter=dbus.service' \


### PR DESCRIPTION
It is always installed unconditionally via the udev-rules module, so it is redundant in this module.

https://github.com/dracut-ng/dracut/blob/ed81bbd9199df18c1452fc58b5554ed6213cae48/modules.d/74udev-rules/module-setup.sh#L39

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
