### PR TITLE
fix(lsinitrd): do no sort cpio output if not needed

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -308,7 +308,7 @@ list_files() {
     if [ "$sorted" -eq 1 ]; then
         cpio_list | sort -n -k5
     else
-        cpio_list | sort -k9
+        cpio_list
     fi
     ((ret += $?))
     echo "========================================================================"


### PR DESCRIPTION
lsinitrd will try to sort the cpio output by the file which is normally key 9, but this is not the case for special files. Therefore special files are shown first:

```
drwxr-xr-x   2 root     root            0 Aug 19 15:31 .
crw-r--r--   1 root     root       5,   1 Aug 19 15:31 dev/console
crw-r--r--   1 root     root       1,  11 Aug 19 15:31 dev/kmsg
crw-r--r--   1 root     root       1,   3 Aug 19 15:31 dev/null
crw-r--r--   1 root     root       1,   8 Aug 19 15:31 dev/random
crw-r--r--   1 root     root       1,   9 Aug 19 15:31 dev/urandom
lrwxrwxrwx   1 root     root            7 Aug 19 15:31 bin -> usr/bin
drwxr-xr-x   2 root     root            0 Aug 19 15:31 dev
drwxr-xr-x   2 root     root            0 Aug 19 15:31 etc
[...]
```

This sorting is confusing and not needed in the normal case. Normally the content of the cpio is already sorted. So removing the sorting. Then the output is in correct order:

```
drwxr-xr-x   2 root     root            0 Aug 19 15:31 .
lrwxrwxrwx   1 root     root            7 Aug 19 15:31 bin -> usr/bin
drwxr-xr-x   2 root     root            0 Aug 19 15:31 dev
crw-r--r--   1 root     root       5,   1 Aug 19 15:31 dev/console
crw-r--r--   1 root     root       1,  11 Aug 19 15:31 dev/kmsg
crw-r--r--   1 root     root       1,   3 Aug 19 15:31 dev/null
crw-r--r--   1 root     root       1,   8 Aug 19 15:31 dev/random
crw-r--r--   1 root     root       1,   9 Aug 19 15:31 dev/urandom
drwxr-xr-x   2 root     root            0 Aug 19 15:31 etc
[...]
```

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
