### PR TITLE
fix(test): bound webserver startup wait with liveness and timeout checks

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -220,7 +220,24 @@ start_webserver() {
             pid=$!
             echo "$pid" > "$TESTDIR/webserver.pid"
 
+            # Wait for the server to announce itself, but never spin
+            # forever: if python3 is missing or dies, or the banner never
+            # appears (e.g. port conflict), fail loudly instead of hanging
+            # the whole test job.
+            # Generous wait budget: 60 s total; python3 -m http.server can
+            # be slow to print its banner on emulated architectures.
+            retries=1200 # 1200 * 0.05 s = 60 s
             while ! grep -q 'Serving HTTP on' "$TESTDIR/webserver.log"; do
+                if ! kill -0 "$pid" 2> /dev/null; then
+                    echo "Error: webserver (pid $pid) died while starting, see $TESTDIR/webserver.log" >&2
+                    return 1
+                fi
+                retries=$((retries - 1))
+                if [ "$retries" -le 0 ]; then
+                    echo "Error: webserver did not announce within 60 s, see $TESTDIR/webserver.log" >&2
+                    kill "$pid" 2> /dev/null
+                    return 1
+                fi
                 echo "sleeping..." >&2
                 sleep 0.05
             done


### PR DESCRIPTION
## Problem

`test/test-functions`, `start_webserver()` (HTTP branch) waits for the banner text `Serving HTTP on` to appear in the python3 http.server log:

```bash
python3 -u -m http.server -d "$TESTDIR" 0 > "$TESTDIR/webserver.log" 2>&1 &
pid=$!
...
while ! grep -q 'Serving HTTP on' "$TESTDIR/webserver.log"; do
    echo "sleeping..." >&2
    sleep 0.05
done
```

Two failure modes both hang the CI job forever with zero diagnostics:
- `python3` missing (or otherwise dies instantly): `kill -0 "$pid"` isn't used, so we spin on grep forever
- server alive but banner never appears (e.g. port conflict, module failing after import): no timeout

Reachable today: TEST-45-SYSTEMD-IMPORT calls `start_webserver` but its `test_check()` never verifies python3 (TEST-31-LIVENET does). TEST-31-LIVENET would also hang if python3 died after test_check's probe succeeded.

## Fix

Bounded retry (1200 × 0.05 s = 60 s — generous for slow emulated architectures) plus a `kill -0 "$pid"` liveness check. On the failure path we print the log file path for diagnosis — the usual place to capture stdout into a variable (`port=$(start_webserver)`) means the log output would otherwise be swallowed.

No functional change on the success path.

## Verification

Ran the **real** `test/test-functions` in a sandbox (`unshare` + bind-mounted stub python3), before/after:

| variant | behavior |
|---|---|
| healthy python3 | baseline: works, returns port; fixed: identical, ~0 s |
| python3 stub `exit 1` | baseline: **hangs forever** (still spinning "sleeping..." at 15 s when `timeout` killed it); fixed: `Error: webserver (pid …) died while starting, see …/webserver.log` in 0 s, `rc=1` |
| python3 stub `sleep 1000` (alive but never announces) | baseline: hangs forever; fixed: `Error: webserver did not announce within 60 s …`, `rc=1` at 60 s |

`shellcheck -s bash test/test-functions`: only the pre-existing SC2034 warning that also fires on the file at origin/main (unrelated to this change).

## Context

Spotted during an audit of the test harness; while writing this I also noted 67996650's HTTPS branch sets a fixed port and doesn't wait at all — if python3-style failure modes matter for the openssl server too, that's a follow-up (HTTPS has no grep-wait loop, so it never hangs; it only risks a silent half-start, which is a different bug class).
