### PR TITLE
ci(azurelinux): revert Azure Linux v3.0 workarounds

### DIFF
--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -20,6 +20,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     chrony \
     cifs-utils \
     cryptsetup \
+    device-mapper-multipath \
     dhcpcd \
     diffutils \
     dnsmasq \
@@ -61,7 +62,3 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     xfsprogs \
     xorriso \
     && dnf -y update && dnf clean all
-
-# disable systemd-portabled - it is optional and allows to pass the CI
-RUN \
-    rm -rf /usr/bin/portablectl /usr/lib/systemd/systemd-portabled ;\

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -63,7 +63,5 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     && dnf -y update && dnf clean all
 
 # disable systemd-portabled - it is optional and allows to pass the CI
-# disable multipath dracut module - it interferes with the CI on azurelinux
 RUN \
     rm -rf /usr/bin/portablectl /usr/lib/systemd/systemd-portabled ;\
-    echo 'omit_dracutmodules+=" multipath "' > /usr/lib/dracut/dracut.conf.d/02-dist.conf


### PR DESCRIPTION
 - ci(azurelinux): revert disabling multipath dracut module
 - ci(azurelinux): revert removing some binaries to workaround test failures
 
 CC @eric-desrochers @chewi @christopherco @gmileka 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
