### PR TITLE
network-legacy: Change `ip=any` to mean dual stack DHCP

### DIFF
--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -42,6 +42,7 @@ jobs:
                     - gentoo:latest
                 test:
                     - "50"
+                    - "51"
                     - "60"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}

--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -607,9 +607,12 @@ options; refer to the documentation of the specific network module in use. For
 NetworkManager, see man:nm-initrd-generator[8].
 
 **ip=**__{dhcp|on|any|dhcp6|auto6|either6|link6|single-dhcp}__::
-    dhcp|on|any::: get ip from dhcp server from all interfaces. If netroot=dhcp,
-    loop sequentially through all interfaces (eth0, eth1, ...) and use the first
-    with a valid DHCP root-path.
+    More than one of the following options can be given, separated by commas.
+    Each is tried in turn until one succeeds.
+
+    dhcp|on::: Get an IP from an IPv4 DHCP server for each interface. If
+    netroot=dhcp, loop sequentially through all interfaces (eth0, eth1, ...)
+    and use the first with a valid DHCP root-path.
 
     single-dhcp::: Send DHCP on all available interfaces in parallel, as
     opposed to one after another. After the first DHCP response is received,
@@ -617,7 +620,7 @@ NetworkManager, see man:nm-initrd-generator[8].
     using the IP on interface for which DHCP succeeded first during early boot.
     Caveat: Does not apply to Network Manager.
 
-    auto6::: IPv6 autoconfiguration
+    auto6::: IPv6 autoconfiguration (SLAAC)
 
     dhcp6::: IPv6 DHCP
 
@@ -625,32 +628,27 @@ NetworkManager, see man:nm-initrd-generator[8].
 
     link6::: bring up interface for IPv6 link-local addressing
 
-**ip=**__<interface>__:__{dhcp|on|any|dhcp6|auto6|link6}__[:[__<mtu>__][:__<macaddr>__]]::
+    any::: Get an IP from an IPv4 and an IPv6 DHCP server and attempt IPv6
+    autoconfiguration (SLAAC) on each interface. All methods are tried in
+    parallel, but only one is required to succeed.
+
+**ip=**__<interface>__:__{dhcp|on|any|dhcp6|auto6|either6|link6}__[:[__<mtu>__][:__<macaddr>__]]::
     This parameter can be specified multiple times.
 +
 =====================
-dhcp|on|any|dhcp6::: get ip from dhcp server on a specific interface
-auto6::: do IPv6 autoconfiguration
-link6::: bring up interface for IPv6 link local address
 <macaddr>::: optionally **set** <macaddr> on the <interface>. This
 cannot be used in conjunction with the **ifname** argument for the
 same <interface>.
 =====================
 
-**ip=**__<client-IP>__:[__<peer>__]:__<gateway-IP>__:__<netmask>__:__<client_hostname>__:__<interface>__:__{none|off|dhcp|on|any|dhcp6|auto6|ibft}__[:[__<mtu>__][:__<macaddr>__]]::
+**ip=**__<client-IP>__:[__<peer>__]:__<gateway-IP>__:__<netmask>__:__<client_hostname>__:__<interface>__:__{none|off|dhcp|on|any|dhcp6|auto6|either6|link6|ibft}__[:[__<mtu>__][:__<macaddr>__]]::
     explicit network configuration. If you want do define a IPv6 address, put it
     in brackets (e.g. [2001:DB8::1]). This parameter can be specified multiple
     times. __<peer>__ is optional and is the address of the remote endpoint
     for pointopoint interfaces and it may be followed by a slash and a decimal
     number, encoding the network prefix length.
-+
-=====================
-<macaddr>::: optionally **set** <macaddr> on the <interface>. This
-cannot be used in conjunction with the **ifname** argument for the
-same <interface>.
-=====================
 
-**ip=**__<client-IP>__:[__<peer>__]:__<gateway-IP>__:__<netmask>__:__<client_hostname>__:__<interface>__:__{none|off|dhcp|on|any|dhcp6|auto6|ibft}__[:[__<dns1>__][:__<dns2>__]]::
+**ip=**__<client-IP>__:[__<peer>__]:__<gateway-IP>__:__<netmask>__:__<client_hostname>__:__<interface>__:__{none|off|dhcp|on|any|dhcp6|auto6|either6|link6|ibft}__[:[__<dns1>__][:__<dns2>__]]::
     explicit network configuration. If you want do define a IPv6 address, put it
     in brackets (e.g. [2001:DB8::1]). This parameter can be specified multiple
     times. __<peer>__ is optional and is the address of the remote endpoint

--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -75,12 +75,12 @@ setup_interface() {
     fi
 
     if getargbool 1 rd.peerdns; then
-        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".IPv4.resolv.conf
         if [ -n "$namesrv" ]; then
             for s in $namesrv; do
                 echo nameserver "$s"
             done
-        fi >> /tmp/net."$netif".resolv.conf
+        fi >> /tmp/net."$netif".IPv4.resolv.conf
     fi
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicitly add any domain if set.
@@ -107,12 +107,12 @@ setup_interface6() {
         ${preferred_lft:+preferred_lft ${preferred_lft}}
 
     if getargbool 1 rd.peerdns; then
-        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".IPv6.resolv.conf
         if [ -n "$namesrv" ]; then
             for s in $namesrv; do
                 echo nameserver "$s"
             done
-        fi >> /tmp/net."$netif".resolv.conf
+        fi >> /tmp/net."$netif".IPv6.resolv.conf
     fi
 
     # Note: hostname can be fqdn OR short hostname, so chop off any
@@ -237,20 +237,26 @@ case $reason in
         fi
         unset layer2
         setup_interface
+
+        # Classless static routes (DHCP option 121) are IPv4-only. Record them
+        # alongside the default route in the per-interface gw file, which
+        # setup_net sources, rather than embedding them in the setup_net hook
+        # below (which a concurrent IPv6 lease would overwrite).
+        if [ -n "$new_classless_static_routes" ]; then
+            OLDIFS="$IFS"
+            IFS=".$IFS"
+            parse_option_121 "$new_classless_static_routes" >> /tmp/net."$netif".gw
+            IFS="$OLDIFS"
+        fi
+
         set | while read -r line || [ -n "$line" ]; do
             [ "${line#new_}" = "$line" ] && continue
             echo "$line"
-        done > /tmp/dhclient."$netif".dhcpopts
+        done > /tmp/dhclient."$netif".IPv4.dhcpopts
 
         {
             echo '. /lib/net-lib.sh'
             echo "setup_net $netif"
-            if [ -n "$new_classless_static_routes" ]; then
-                OLDIFS="$IFS"
-                IFS=".$IFS"
-                parse_option_121 "$new_classless_static_routes"
-                IFS="$OLDIFS"
-            fi
             echo "source_hook initqueue/online $netif"
             [ -e /tmp/net."$netif".manualup ] || echo "/sbin/netroot $netif"
             echo "rm -f -- $hookdir/initqueue/setup_net_$netif.sh"
@@ -282,7 +288,7 @@ case $reason in
         set | while read -r line || [ -n "$line" ]; do
             [ "${line#new_}" = "$line" ] && continue
             echo "$line"
-        done > /tmp/dhclient."$netif".dhcpopts
+        done > /tmp/dhclient."$netif".IPv6.dhcpopts
 
         {
             echo '. /lib/net-lib.sh'

--- a/modules.d/35network-legacy/dhcp-multi.sh
+++ b/modules.d/35network-legacy/dhcp-multi.sh
@@ -11,7 +11,9 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 netif=$1
 do_vlan=$2
-arg=$3
+_IPv=${3:-4}
+_tmp_prefix="/tmp/dhclient.${netif}.IPv${_IPv}"
+shift 3
 
 # Run dhclient in parallel
 do_dhclient() {
@@ -29,14 +31,14 @@ do_dhclient() {
     fi
 
     while [ $_COUNT -lt "$_DHCPRETRY" ]; do
-        info "Starting dhcp for interface $netif"
-        dhclient "$arg" \
+        info "Starting IPv$_IPv dhcp for interface $netif"
+        dhclient -"${_IPv}" "$@" \
             ${_timeout:+--timeout "$_timeout"} \
             -q \
             -1 \
             -cf /etc/dhclient.conf \
-            -pf /tmp/dhclient."$netif".pid \
-            -lf /tmp/dhclient."$netif".lease \
+            -pf "${_tmp_prefix}.pid" \
+            -lf "${_tmp_prefix}.lease" \
             "$netif" &
         wait $! 2> /dev/null
 
@@ -51,16 +53,16 @@ do_dhclient() {
         # If dhclient exited before wait was called, or it was killed by
         # another thread for interface whose DHCP succeeded, then it will not
         # find the process with that pid and return error code 127. In that
-        # case we need to check if /tmp/dhclient.$netif.lease exists. If it
-        # does, it means dhclient finished executing before wait was called,
-        # and it was successful (return 0). If /tmp/dhclient.$netif.lease
-        # does not exist, then it means dhclient was killed by another thread
-        # or it finished execution but failed dhcp on that interface.
+        # case we need to check if /tmp/dhclient.$netif.IPvX.lease exists. If
+        # it does, it means dhclient finished executing before wait was
+        # called, and it was successful (return 0). If the lease file does not
+        # exist, then it means dhclient was killed by another thread or it
+        # finished execution but failed dhcp on that interface.
 
         if [ $retv -eq 127 ]; then
-            read -r pid < /tmp/dhclient."$netif".pid
+            read -r pid < "${_tmp_prefix}.pid"
             info "PID $pid was not found by wait for $netif"
-            if [ -e /tmp/dhclient."$netif".lease ]; then
+            if [ -e "${_tmp_prefix}.lease" ]; then
                 info "PID $pid not found but DHCP successful on $netif"
                 return 0
             fi
@@ -69,14 +71,13 @@ do_dhclient() {
         _COUNT=$((_COUNT + 1))
         [ $_COUNT -lt "$_DHCPRETRY" ] && sleep 1
     done
-    warn "dhcp for interface $netif failed"
-    # nuke those files since we failed; we might retry dhcp again if it's e.g.
-    # `ip=dhcp,dhcp6` and we check for the PID file earlier
-    rm -f /tmp/dhclient."$netif".pid /tmp/dhclient."$netif".lease
+    warn "IPv$_IPv dhcp for interface $netif failed"
+    # nuke those files since we failed
+    rm -f "${_tmp_prefix}.pid" "${_tmp_prefix}.lease"
     return 1
 }
 
-do_dhclient
+do_dhclient "$@"
 ret=$?
 
 # setup nameserver
@@ -111,22 +112,22 @@ if [ $ret -eq 0 ]; then
 
     if ln -s "$netif" "$IFNETFILE" 2> /dev/null; then
         intf=$(readlink "$IFNETFILE")
-        if [ -e /tmp/dhclient."$intf".lease ]; then
-            info "DHCP successful on interface $intf"
+        if [ -e "/tmp/dhclient.$intf.IPv$_IPv.lease" ]; then
+            info "IPv$_IPv DHCP successful on interface $intf"
             # Kill all existing dhclient calls for other interfaces, since we
             # already got one successful interface
 
-            read -r npid < /tmp/dhclient."$netif".pid
+            read -r npid < "${_tmp_prefix}.pid"
             pidlist=$(pgrep dhclient)
             for pid in $pidlist; do
                 [ "$pid" -eq "$npid" ] && continue
                 kill -9 "$pid" > /dev/null 2>&1
             done
         else
-            echo "ERROR! $IFNETFILE exists but /tmp/dhclient.$intf.lease does not exist!!!"
+            echo "ERROR! $IFNETFILE exists but /tmp/dhclient.$intf.IPv$_IPv.lease does not exist!!!"
         fi
     else
-        info "DHCP success on $netif, and also on $intf"
+        info "IPv$_IPv DHCP success on $netif, and also on $intf"
         exit 0
     fi
     exit $ret

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -28,7 +28,14 @@ do_dhcp_parallel() {
     # event for nfsroot
     # XXX add -V vendor class and option parsing per kernel
 
-    [ -e "/tmp/dhclient.$netif.pid" ] && return 0
+    local _IPv
+    local _tmp_prefix
+
+    _IPv=${1:-4}
+    _tmp_prefix="/tmp/dhclient.${netif}.IPv${_IPv}"
+    shift
+
+    [ -e "${_tmp_prefix}.pid" ] && return 0
 
     if ! iface_has_carrier "$netif"; then
         warn "No carrier detected on interface $netif"
@@ -36,7 +43,7 @@ do_dhcp_parallel() {
     fi
 
     bootintf=$(readlink "$IFNETFILE")
-    if [ -n "$bootintf" ] && [ -e "/tmp/dhclient.${bootintf}.lease" ]; then
+    if [ -n "$bootintf" ] && [ -e "${_tmp_prefix}.lease" ]; then
         info "DHCP already succeeded for $bootintf, exiting for $netif"
         return 1
     fi
@@ -47,7 +54,7 @@ do_dhcp_parallel() {
         echo 'dhcp=dhclient' >> /run/NetworkManager/conf.d/10-dracut-dhclient.conf
     fi
 
-    /sbin/dhcp-multi.sh "$netif" "$DO_VLAN" "$@" &
+    /sbin/dhcp-multi.sh "$netif" "$DO_VLAN" "$_IPv" "$@" &
     return 0
 }
 
@@ -60,12 +67,18 @@ do_dhcp() {
     local _COUNT
     local _timeout
     local _DHCPRETRY
+    local _IPv
+    local _tmp_prefix
 
     _COUNT=0
     _timeout=$(getarg rd.net.timeout.dhcp=)
     _DHCPRETRY=$(getargnum 1 1 1000000000 rd.net.dhcp.retry=)
 
-    [ -e "/tmp/dhclient.${netif}.pid" ] && return 0
+    _IPv=${1:-4}
+    _tmp_prefix="/tmp/dhclient.${netif}.IPv${_IPv}"
+    shift
+
+    [ -e "${_tmp_prefix}.pid" ] && return 0
 
     if ! iface_has_carrier "$netif"; then
         warn "No carrier detected on interface $netif"
@@ -86,23 +99,22 @@ do_dhcp() {
     fi
 
     while [ "$_COUNT" -lt "$_DHCPRETRY" ]; do
-        info "Starting dhcp for interface $netif"
-        dhclient "$@" \
+        info "Starting IPv$_IPv dhcp for interface $netif"
+        dhclient -"${_IPv}" "$@" \
             ${_timeout:+--timeout "$_timeout"} \
             -q \
             -1 \
             -cf /etc/dhclient.conf \
-            -pf "/tmp/dhclient.${netif}.pid" \
-            -lf "/tmp/dhclient.${netif}.lease" \
+            -pf "${_tmp_prefix}.pid" \
+            -lf "${_tmp_prefix}.lease" \
             "$netif" \
             && return 0
         _COUNT=$((_COUNT + 1))
         [ "$_COUNT" -lt "$_DHCPRETRY" ] && sleep 1
     done
-    warn "dhcp for interface $netif failed"
-    # nuke those files since we failed; we might retry dhcp again if it's e.g.
-    # `ip=dhcp,dhcp6` and we check for the PID file at the top
-    rm -f /tmp/dhclient."$netif".pid /tmp/dhclient."$netif".lease
+    warn "IPv$_IPv dhcp for interface $netif failed"
+    # nuke those files since we failed
+    rm -f "${_tmp_prefix}.pid" "${_tmp_prefix}.lease"
     return 1
 }
 
@@ -117,6 +129,9 @@ load_ipv6() {
     done
 }
 
+# do_ipv6auto [<timeout>]
+# <timeout> is passed to wait_for_ipv6_auto to shorten the SLAAC wait when it
+# is only opportunistic (e.g. as part of ip=any).
 do_ipv6auto() {
     local ret
     load_ipv6
@@ -124,7 +139,7 @@ do_ipv6auto() {
     echo 1 > /proc/sys/net/ipv6/conf/"${netif}"/accept_ra
     echo 1 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
     linkup "$netif"
-    wait_for_ipv6_auto "$netif"
+    wait_for_ipv6_auto "$netif" "$1"
     ret=$?
 
     [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
@@ -466,24 +481,47 @@ for p in $(getargs ip=); do
         eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
     done > "/tmp/net.$netif.override"
 
+    ret=1
     for autoopt in $(str_replace "$autoconf" "," " "); do
         case $autoopt in
-            dhcp | on | any)
-                do_dhcp -4
+            any)
+                # Run all three methods in parallel, requiring just one to
+                # succeed, so a missing server for one family does not add its
+                # timeout on top of the others. SLAAC is only opportunistic
+                # here, so give it a short timeout rather than the full
+                # rd.net.timeout.ipv6auto: on links without SLAAC, it must not
+                # stall once DHCP has succeeded.
+                do_dhcp 4 &
+                _pid4=$!
+                load_ipv6
+                do_ipv6auto 10 &
+                _pid6auto=$!
+                do_dhcp 6 &
+                _pid6dhcp=$!
+                wait "$_pid4"
+                r4=$?
+                wait "$_pid6auto"
+                r6auto=$?
+                wait "$_pid6dhcp"
+                r6dhcp=$?
+                [ $r4 -eq 0 ] || [ $r6auto -eq 0 ] || [ $r6dhcp -eq 0 ]
+                ;;
+            dhcp | on)
+                do_dhcp 4
                 ;;
             single-dhcp)
-                do_dhcp_parallel -4
+                do_dhcp_parallel 4
                 exit 0
                 ;;
             dhcp6)
                 load_ipv6
-                do_dhcp -6
+                do_dhcp 6
                 ;;
             auto6)
                 do_ipv6auto
                 ;;
             either6)
-                do_ipv6auto || do_dhcp -6
+                do_ipv6auto || do_dhcp 6
                 ;;
             link6)
                 do_ipv6link
@@ -492,8 +530,9 @@ for p in $(getargs ip=); do
                 do_static
                 ;;
         esac
+        ret=$?
+        [ $ret -eq 0 ] && break
     done
-    ret=$?
 
     # setup nameserver
     for s in "$dns1" "$dns2" $(getargs nameserver); do
@@ -528,7 +567,7 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
     if [ -e /tmp/net.bootdev ]; then
         read -r BOOTDEV < /tmp/net.bootdev
         if [ "$netif" = "$BOOTDEV" ] || [ "$BOOTDEV" = "$(cat "/sys/class/net/${netif}/address")" ]; then
-            do_dhcp
+            do_dhcp 4
             ret=$?
         fi
     else
@@ -537,11 +576,11 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
 
         if getargs 'ip=dhcp6' > /dev/null || [ -z "$ip" ] && [ "$netroot" = "dhcp6" ]; then
             load_ipv6
-            do_dhcp -6
+            do_dhcp 6
             ret=$?
         fi
         if getargs 'ip=dhcp' > /dev/null || [ -z "$ip" ] && [ "$netroot" != "dhcp6" ]; then
-            do_dhcp -4
+            do_dhcp 4
             ret=$?
         fi
     fi

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -137,11 +137,26 @@ setup_net() {
     [ -e /tmp/net."$netif".hostname ] && . /tmp/net."$netif".hostname
     # shellcheck disable=SC1090
     [ -e /tmp/net."$netif".override ] && . /tmp/net."$netif".override
+    # network-legacy records DHCP options per-protocol to avoid a concurrent
+    # dual-stack write race; merge them back into the single file that netroot,
+    # nfs and chrony consume (as the NetworkManager and networkd backends write
+    # it directly), then source it.
+    if [ -e /tmp/dhclient."$netif".IPv4.dhcpopts ] || [ -e /tmp/dhclient."$netif".IPv6.dhcpopts ]; then
+        cat /tmp/dhclient."$netif".IPv4.dhcpopts /tmp/dhclient."$netif".IPv6.dhcpopts 2> /dev/null \
+            > /tmp/dhclient."$netif".dhcpopts
+    fi
     # shellcheck disable=SC1090
     [ -e /tmp/dhclient."$netif".dhcpopts ] && . /tmp/dhclient."$netif".dhcpopts
-    # set up resolv.conf
-    [ -e /tmp/net."$netif".resolv.conf ] \
-        && awk '!array[$0]++' /tmp/net."$netif".resolv.conf > /etc/resolv.conf
+    # set up resolv.conf, merging the cmdline, IPv4 and IPv6 nameservers and
+    # dropping any duplicate lines
+    if [ -e /tmp/net."$netif".resolv.conf ] \
+        || [ -e /tmp/net."$netif".IPv4.resolv.conf ] \
+        || [ -e /tmp/net."$netif".IPv6.resolv.conf ]; then
+        cat /tmp/net."$netif".resolv.conf \
+            /tmp/net."$netif".IPv4.resolv.conf \
+            /tmp/net."$netif".IPv6.resolv.conf 2> /dev/null \
+            | awk '!array[$0]++' > /etc/resolv.conf
+    fi
     # shellcheck disable=SC1090
     [ -e /tmp/net."$netif".gw ] && . /tmp/net."$netif".gw
 
@@ -757,16 +772,19 @@ wait_for_ipv6_dad() {
     return 1
 }
 
+# wait_for_ipv6_auto <interface> [<timeout>]
+# <timeout> overrides rd.net.timeout.ipv6auto= (in seconds); used by callers
+# for which SLAAC is opportunistic and should not block for long.
 wait_for_ipv6_auto() {
     local cnt=0
     local timeout
-    timeout=$(getargs rd.net.timeout.ipv6auto=)
+    timeout=${2:-$(getargs rd.net.timeout.ipv6auto=)}
     timeout=${timeout:-40}
     timeout=$((timeout * 10))
 
     while [ $cnt -lt $timeout ]; do
-        [ -z "$(ip -6 addr show dev "$@" tentative)" ] \
-            && { ip -6 route list proto ra dev "$@" | grep -q ^default; } \
+        [ -z "$(ip -6 addr show dev "$1" tentative)" ] \
+            && { ip -6 route list proto ra dev "$1" | grep -q ^default; } \
             && return 0
         sleep 0.1
         cnt=$((cnt + 1))

--- a/test/TEST-51-NETWORK-LEGACY/Makefile
+++ b/test/TEST-51-NETWORK-LEGACY/Makefile
@@ -1,0 +1,1 @@
+-include ../Makefile.testdir

--- a/test/TEST-51-NETWORK-LEGACY/assertion.sh
+++ b/test/TEST-51-NETWORK-LEGACY/assertion.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -eu
+
+# required binaries: grep ip
+
+# The client booted with several NICs, each using a different ip= autoconf mode
+# against a dnsmasq server serving both DHCPv4 and stateful DHCPv6. Verify each
+# interface ended up with exactly the address families its mode implies. Any
+# mismatch is appended to /run/failed, which test-init.sh treats as a failure.
+
+fail() {
+    echo "FAILED: $1" >> /run/failed
+    ip -o addr show >> /run/failed 2>&1 || true
+}
+
+has_ipv4() {
+    ip -o -4 addr show dev "$1" scope global 2> /dev/null | grep -q 'inet '
+}
+
+# A DHCPv6 address has a short host part (e.g. 2001:db8:51::100/128), unlike a
+# SLAAC EUI-64 address, so matching it specifically proves the DHCPv6 half ran.
+has_dhcpv6() {
+    ip -o -6 addr show dev "$1" scope global 2> /dev/null \
+        | grep -Eq "inet6 $2::[0-9a-f]{1,4}/"
+}
+
+# A SLAAC address lives in the link's /64 prefix but (unlike a DHCPv6 address)
+# has a full 64-bit host part. Since the SLAAC links run no DHCPv6 server, any
+# global address in the prefix must have come from SLAAC.
+has_slaac() {
+    ip -o -6 addr show dev "$1" scope global 2> /dev/null | grep -q "inet6 $2:"
+}
+
+# Count global IPv6 addresses on an interface. Used to confirm an interface
+# obtained both a DHCPv6 and a SLAAC address (i.e. two of them).
+count_global_ipv6() {
+    ip -o -6 addr show dev "$1" scope global 2> /dev/null | grep -c 'inet6 ' || true
+}
+
+# netdhcp: ip=dhcp -> IPv4 only, and specifically no DHCPv6 address. Matching a
+# DHCPv6-style address (rather than any global IPv6) means an incidental SLAAC
+# address would be ignored, while a stray dhclient -6 run would still be caught.
+has_ipv4 netdhcp || fail "netdhcp (dhcp): missing IPv4 address"
+if has_dhcpv6 netdhcp 2001:db8:51; then
+    fail "netdhcp (dhcp): unexpected DHCPv6 address"
+fi
+
+# netdhcp6: ip=dhcp6 -> DHCPv6 IPv6 only, no IPv4.
+has_dhcpv6 netdhcp6 2001:db8:52 || fail "netdhcp6 (dhcp6): missing DHCPv6 address"
+if has_ipv4 netdhcp6; then
+    fail "netdhcp6 (dhcp6): unexpected IPv4 address"
+fi
+
+# netany: ip=any -> IPv4, DHCPv6 and SLAAC. The .53 link offers stateful DHCPv6
+# and SLAAC, so a correct dual-stack "any" (do_dhcp 4 + do_dhcp 6 + do_ipv6auto)
+# ends up with an IPv4 address plus two global IPv6 addresses: one DHCPv6 (short
+# host part) and one SLAAC.
+has_ipv4 netany || fail "netany (any): missing IPv4 address"
+has_dhcpv6 netany 2001:db8:53 || fail "netany (any): missing DHCPv6 address"
+[ "$(count_global_ipv6 netany)" -ge 2 ] \
+    || fail "netany (any): expected both a DHCPv6 and a SLAAC address"
+
+# netauto6: ip=auto6 -> SLAAC IPv6 only, no IPv4.
+has_slaac netauto6 2001:db8:54 || fail "netauto6 (auto6): missing SLAAC address"
+if has_ipv4 netauto6; then
+    fail "netauto6 (auto6): unexpected IPv4 address"
+fi
+
+# neteither6: ip=either6 -> SLAAC IPv6 (auto6 path succeeds), no IPv4.
+has_slaac neteither6 2001:db8:55 || fail "neteither6 (either6): missing SLAAC address"
+if has_ipv4 neteither6; then
+    fail "neteither6 (either6): unexpected IPv4 address"
+fi

--- a/test/TEST-51-NETWORK-LEGACY/dnsmasq.conf
+++ b/test/TEST-51-NETWORK-LEGACY/dnsmasq.conf
@@ -1,0 +1,39 @@
+dhcp-leasefile=/run/dnsmasq.leases
+log-dhcp
+log-facility=-
+no-hosts
+no-resolv
+user=root
+group=root
+pid-file=
+
+interface=enx525400123456
+interface=enx525400123457
+interface=enx525400123458
+interface=enx525400123459
+interface=enx52540012345a
+bind-interfaces
+
+# IPv4 pools, one per DHCP link.
+dhcp-range=192.168.51.100,192.168.51.200,255.255.255.0,12h
+dhcp-range=192.168.52.100,192.168.52.200,255.255.255.0,12h
+dhcp-range=192.168.53.100,192.168.53.200,255.255.255.0,12h
+
+# Stateful DHCPv6 pools. With explicit address ranges and no "slaac" keyword,
+# dnsmasq advertises the prefix without the autonomous flag, so clients on the
+# .51 and .52 links only obtain an address via DHCPv6, never SLAAC. enable-ra
+# also supplies the default route (DHCPv6 does not carry routes).
+enable-ra
+dhcp-range=2001:db8:51::100,2001:db8:51::200,64,12h
+dhcp-range=2001:db8:52::100,2001:db8:52::200,64,12h
+
+# The .53 link (netany, ip=any) offers stateful DHCPv6 AND SLAAC: the "slaac"
+# keyword additionally sets the autonomous flag, so a dual-stack "any" (which
+# now runs both do_dhcp 6 and do_ipv6auto) ends up with a DHCPv6 and a SLAAC
+# address.
+dhcp-range=2001:db8:53::100,2001:db8:53::200,slaac,64,12h
+
+# RA/SLAAC-only links (no DHCPv6 server): ra-only advertises the prefix with the
+# autonomous flag set, so the client autoconfigures an address via SLAAC.
+dhcp-range=2001:db8:54::,ra-only
+dhcp-range=2001:db8:55::,ra-only

--- a/test/TEST-51-NETWORK-LEGACY/server-init.sh
+++ b/test/TEST-51-NETWORK-LEGACY/server-init.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+# required binaries: dnsmasq ip mount pidof poweroff sleep
+
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+# shellcheck disable=SC2317,SC2329  # called via EXIT trap
+_poweroff() {
+    local exit_code="$?"
+
+    set +x
+    [ "$exit_code" -eq 0 ] || echo "Error: $0 failed with exit code $exit_code."
+    echo "Powering down."
+
+    poweroff -f
+}
+
+trap _poweroff EXIT
+
+exec < /dev/console > /dev/console 2>&1
+set -x
+export TERM=linux
+export PS1='legacy-server:\w\$ '
+echo "made it to the network-legacy DHCP server rootfs!"
+echo server > /proc/sys/kernel/hostname
+
+wait_for_if_link() {
+    local cnt=0
+    local li
+    while [ $cnt -lt 600 ]; do
+        li=$(ip -o link show dev "$1" 2> /dev/null)
+        [ -n "$li" ] && return 0
+        sleep 0.1
+        cnt=$((cnt + 1))
+    done
+    return 1
+}
+
+# configure <iface> <ipv4/prefix> <ipv6/prefix>
+configure() {
+    wait_for_if_link "$1"
+    ip link set "$1" up
+    ip addr add "$2" dev "$1"
+    ip -6 addr add "$3" dev "$1" nodad
+}
+
+# configure_v6 <iface> <ipv6/prefix>
+configure_v6() {
+    wait_for_if_link "$1"
+    ip link set "$1" up
+    ip -6 addr add "$2" dev "$1" nodad
+}
+
+# Static addresses matching the dnsmasq pools below, one link per client NIC.
+# The first three are DHCPv4 + stateful DHCPv6 links; the last two are RA/SLAAC
+# only.
+configure enx525400123456 192.168.51.1/24 2001:db8:51::1/64
+configure enx525400123457 192.168.52.1/24 2001:db8:52::1/64
+configure enx525400123458 192.168.53.1/24 2001:db8:53::1/64
+configure_v6 enx525400123459 2001:db8:54::1/64
+configure_v6 enx52540012345a 2001:db8:55::1/64
+
+dnsmasq
+echo "Serving DHCP"
+while pidof dnsmasq; do
+    echo > /dev/watchdog
+    sleep 1
+done
+
+mount -n -o remount,ro /

--- a/test/TEST-51-NETWORK-LEGACY/server.link
+++ b/test/TEST-51-NETWORK-LEGACY/server.link
@@ -1,0 +1,6 @@
+[Match]
+OriginalName=*
+
+[Link]
+NamePolicy=mac
+MACAddressPolicy=none

--- a/test/TEST-51-NETWORK-LEGACY/test.sh
+++ b/test/TEST-51-NETWORK-LEGACY/test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -eu
+
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
+# shellcheck disable=SC2034
+TEST_DESCRIPTION="network-legacy ip= autoconf variations (dhcp, dhcp6, any, auto6, either6) against real DHCP servers"
+
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+#SERVER_DEBUG="rd.debug loglevel=7"
+#SERIAL="tcp:127.0.0.1:9999"
+
+# The client is given several NICs, each on its own point-to-point link to a NIC
+# on a dnsmasq server VM. The DHCP links serve both DHCPv4 and (stateful)
+# DHCPv6; the autoconf links serve only RA/SLAAC. Each NIC uses a different ip=
+# autoconf mode, so a single boot exercises several variations. Because every
+# DHCP link has a working DHCPv6 server, this both proves the per-protocol
+# pid/lease separation and makes the test sensitive: a 4<->6 mix-up still brings
+# the interface up with the wrong address family, which the assertion catches.
+#
+#   netdhcp    ip=dhcp    -> IPv4 only            (link 192.168.51.0/24 2001:db8:51::/64)
+#   netdhcp6   ip=dhcp6   -> DHCPv6 IPv6 only      (link 192.168.52.0/24 2001:db8:52::/64)
+#   netany     ip=any     -> IPv4 + DHCPv6 + SLAAC (link 192.168.53.0/24 2001:db8:53::/64)
+#   netauto6   ip=auto6   -> SLAAC IPv6 only       (link 2001:db8:54::/64, RA only)
+#   neteither6 ip=either6 -> SLAAC IPv6 only       (link 2001:db8:55::/64, RA only)
+CLIENT_MAC_DHCP="52:54:00:00:51:00"
+CLIENT_MAC_DHCP6="52:54:00:00:51:01"
+CLIENT_MAC_ANY="52:54:00:00:51:02"
+CLIENT_MAC_AUTO6="52:54:00:00:51:03"
+CLIENT_MAC_EITHER6="52:54:00:00:51:04"
+
+SERVER_MAC0="52:54:00:12:34:56"
+SERVER_MAC1="52:54:00:12:34:57"
+SERVER_MAC2="52:54:00:12:34:58"
+SERVER_MAC3="52:54:00:12:34:59"
+SERVER_MAC4="52:54:00:12:34:5a"
+
+test_check() {
+    if ! "$DRACUT" --list-modules 2> /dev/null | grep -qx network-legacy; then
+        echo "dracut module 'network-legacy' not available; configure with --enable-network-legacy... Skipping"
+        return 1
+    fi
+
+    if ! command -v dhclient &> /dev/null; then
+        echo "dhclient not available, needed by network-legacy... Skipping"
+        return 1
+    fi
+
+    if ! command -v dnsmasq &> /dev/null; then
+        echo "dnsmasq not available, needed by the DHCP test server... Skipping"
+        return 1
+    fi
+}
+
+run_server() {
+    echo "Starting DHCPv4/DHCPv6 server"
+
+    declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/server.img serverroot
+
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
+        -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
+        -device "virtio-net-pci,netdev=lan0,mac=$SERVER_MAC0" \
+        -netdev "dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60510,remote.type=inet,remote.host=localhost,remote.port=60511" \
+        -device "virtio-net-pci,netdev=lan1,mac=$SERVER_MAC1" \
+        -netdev "dgram,id=lan1,local.type=inet,local.host=localhost,local.port=60512,remote.type=inet,remote.host=localhost,remote.port=60513" \
+        -device "virtio-net-pci,netdev=lan2,mac=$SERVER_MAC2" \
+        -netdev "dgram,id=lan2,local.type=inet,local.host=localhost,local.port=60514,remote.type=inet,remote.host=localhost,remote.port=60515" \
+        -device "virtio-net-pci,netdev=lan3,mac=$SERVER_MAC3" \
+        -netdev "dgram,id=lan3,local.type=inet,local.host=localhost,local.port=60516,remote.type=inet,remote.host=localhost,remote.port=60517" \
+        -device "virtio-net-pci,netdev=lan4,mac=$SERVER_MAC4" \
+        -netdev "dgram,id=lan4,local.type=inet,local.host=localhost,local.port=60518,remote.type=inet,remote.host=localhost,remote.port=60519" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
+        -pidfile "$TESTDIR"/server.pid -daemonize \
+        -initrd "$TESTDIR"/initramfs.server
+    chmod 644 "$TESTDIR"/server.pid
+
+    # The server prints "Serving" once dnsmasq is up.
+    if ! [[ ${SERIAL-} ]]; then
+        wait_for_server_startup "./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
+    else
+        echo "Sleeping 10 seconds to give the server a head start"
+        sleep 10
+    fi
+}
+
+test_run() {
+    if ! run_server; then
+        echo "Failed to start server" 1>&2
+        return 1
+    fi
+
+    declare -a disk_args=()
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
+
+    local cmdline="rd.neednet=1 bootdev=netdhcp"
+    cmdline+=" ifname=netdhcp:$CLIENT_MAC_DHCP"
+    cmdline+=" ifname=netdhcp6:$CLIENT_MAC_DHCP6"
+    cmdline+=" ifname=netany:$CLIENT_MAC_ANY"
+    cmdline+=" ifname=netauto6:$CLIENT_MAC_AUTO6"
+    cmdline+=" ifname=neteither6:$CLIENT_MAC_EITHER6"
+    cmdline+=" ip=netdhcp:dhcp ip=netdhcp6:dhcp6 ip=netany:any"
+    cmdline+=" ip=netauto6:auto6 ip=neteither6:either6"
+
+    test_marker_reset
+    "$testdir"/run-qemu \
+        -device "virtio-net-pci,netdev=lan0,mac=$CLIENT_MAC_DHCP" \
+        -netdev "dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60511,remote.type=inet,remote.host=localhost,remote.port=60510" \
+        -device "virtio-net-pci,netdev=lan1,mac=$CLIENT_MAC_DHCP6" \
+        -netdev "dgram,id=lan1,local.type=inet,local.host=localhost,local.port=60513,remote.type=inet,remote.host=localhost,remote.port=60512" \
+        -device "virtio-net-pci,netdev=lan2,mac=$CLIENT_MAC_ANY" \
+        -netdev "dgram,id=lan2,local.type=inet,local.host=localhost,local.port=60515,remote.type=inet,remote.host=localhost,remote.port=60514" \
+        -device "virtio-net-pci,netdev=lan3,mac=$CLIENT_MAC_AUTO6" \
+        -netdev "dgram,id=lan3,local.type=inet,local.host=localhost,local.port=60517,remote.type=inet,remote.host=localhost,remote.port=60516" \
+        -device "virtio-net-pci,netdev=lan4,mac=$CLIENT_MAC_EITHER6" \
+        -netdev "dgram,id=lan4,local.type=inet,local.host=localhost,local.port=60519,remote.type=inet,remote.host=localhost,remote.port=60518" \
+        "${disk_args[@]}" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $cmdline" \
+        -initrd "$TESTDIR"/initramfs.testing
+
+    local ret=0
+    test_marker_check || ret=$?
+    kill_server
+    return "$ret"
+}
+
+make_server_rootfs() {
+    rm -fr "$TESTDIR"/server-rootfs
+    build_rootfs_base "$TESTDIR"/server-rootfs
+
+    binaries=$(sed -n "s/^# required binaries: \(.*\)/\1/p" ./server-init.sh)
+    # shellcheck disable=SC2086
+    inst_multiple $binaries
+    inst_script ./server-init.sh /sbin/init
+    inst ./dnsmasq.conf /etc/dnsmasq.conf
+    echo "root:x:0:0:root:/root:/bin/sh" > "$initdir/etc/passwd"
+    echo "root:x:0:" > "$initdir/etc/group"
+
+    build_ext4_image "$TESTDIR/server-rootfs" "$TESTDIR"/server.img dracut
+    rm -fr "$TESTDIR"/server-rootfs
+}
+
+test_setup() {
+    # client root filesystem, with the dual-stack assertion baked in
+    build_client_rootfs "$TESTDIR/rootfs" ./assertion.sh
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
+
+    # server root filesystem, running dnsmasq as a DHCPv4/DHCPv6 server
+    make_server_rootfs
+
+    # client initramfs: force network-legacy so the 'network' meta-module does
+    # not pick NetworkManager/networkd instead.
+    test_dracut --add-drivers "virtio_net" --add "qemu-net network network-legacy"
+
+    # server initramfs: only needs to rename the NICs (via server.link) and boot
+    # the server root; the network itself is configured by server-init.sh.
+    call_dracut -N \
+        --add-confdir test \
+        -a "$USE_NETWORK ${SERVER_DEBUG:+debug}" \
+        -i "./server.link" "/etc/systemd/network/01-server.link" \
+        -i "./wait-if-server.sh" "/usr/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
+        -f "$TESTDIR"/initramfs.server
+}
+
+kill_server() {
+    if [[ -s $TESTDIR/server.pid ]]; then
+        kill -TERM "$(cat "$TESTDIR"/server.pid)"
+        rm -f -- "$TESTDIR"/server.pid
+    fi
+}
+
+test_cleanup() {
+    kill_server
+}
+
+# shellcheck disable=SC1090
+. "$testdir"/test-functions

--- a/test/TEST-51-NETWORK-LEGACY/wait-if-server.sh
+++ b/test/TEST-51-NETWORK-LEGACY/wait-if-server.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+. /lib/net-lib.sh
+wait_for_if_link enx525400123456

--- a/test/test.sh
+++ b/test/test.sh
@@ -38,7 +38,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
-    -e V -e NO_KVM -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e USE_NETWORK -e TEST_DRACUT_ARGS ${TEST_FSTYPE:+-e TEST_FSTYPE} -e TEST_CONTAINER_COMMAND \
+    -e V -e NO_KVM -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e USE_NETWORK -e TEST_DRACUT_ARGS -e CONFIGURE_ARG ${TEST_FSTYPE:+-e TEST_FSTYPE} -e TEST_CONTAINER_COMMAND \
     -v "$PWD"/:/z \
     "$CONTAINER" \
     /z/test/test-container.sh


### PR DESCRIPTION
systemd-network-generator tries to support the same IP configuration syntax as Dracut. One difference is that Dracut supports multiple comma-separated autoconf values (e.g. `dhcp,dhcp6`) whereas systemd only permits one. Fixing this in systemd may not be straightforward.

This matters because [Afterburn](https://github.com/coreos/afterburn) can emit `dhcp,dhcp6` for KubeVirt, and it is now being adapted to support systemd-network-generator as well as Dracut's network-legacy module.

Even if systemd-network-generator did support multiple values, the behaviour would not be the same. Both systemd-networkd and NetworkManager always try both IPv4 and IPv6, normally requiring just one of them to work, whereas network-legacy will not even try IPv6 if IPv4 works, or vice-versa depending on the order given. It is not currently possible to make network-legacy always try both.

To workaround the lack of multi-value support in systemd and to mirror how systemd and NetworkManager behave, I am changing `ip=any` to always try DHCPv4, DHCPv6, and SLAAC, requiring just one to work. They are tried in parallel to avoid the cost of a double timeout. Despite the name, this is currently treated by network-legacy as IPv4-only. The history of ifup.sh reveals that `any` was supported before IPv6 was, and that IPv6 was initially added with "preliminary" support. Perhaps the author didn't want to change the behaviour of `any` until that support was better established and then forgot, or perhaps it was merely an oversight.

systemd-network-generator also treats `ip=on` as dual stack, but that would be a more controversial change. Users may not expect IPv6 alone to be considered successful. NetworkManager even treats `ip=dhcp` as dual stack, but I feel that is wrong. With `ip=any`, the intent is clearer, and this at least gives us one option where the behaviour is consistent.

Much of this change is adjusting the dhclient PID and lease paths to be protocol-specific so that IPv4 and IPv6 instances can be run simultaneously.

There were no tests for explicit IP configuration at all, but I felt it was important to have this covered, so some have been added. To avoid unnecessary overhead, this spins up just one VM with several differently configured interfaces.

The module changes were mostly written by me with a little help from AI. The tests were entirely written by AI.

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it