### PR TITLE
fix(network-legacy): strip DHCP-supplied domain to a safe charset

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -14,8 +14,9 @@ setup_interface() {
     mask=$new_subnet_mask
     bcast=$new_broadcast_address
     gw=${new_routers%%,*}
-    # get rid of control chars
-    domain=$(printf -- "%s" "$new_domain_name" | tr -d '[:cntrl:]')
+    # get rid of control chars and anything else that is unsafe in
+    # generated shell snippets (/tmp/net.$netif.hostname is sourced later)
+    domain=$(printf -- "%s" "$new_domain_name" | tr -d -c 'a-zA-Z0-9.-')
     search=$(printf -- "%s" "$new_domain_search" | tr -d '[:cntrl:]')
     namesrv=$new_domain_name_servers
     hostname=$(printf '%s' "$new_host_name" | tr -d -c 'a-zA-Z0-9.-')
@@ -88,8 +89,9 @@ setup_interface() {
 }
 
 setup_interface6() {
-    # get rid of control chars
-    domain=$(printf -- "%s" "$new_domain_name" | tr -d '[:cntrl:]')
+    # get rid of control chars and anything else that is unsafe in
+    # generated shell snippets (/tmp/net.$netif.hostname is sourced later)
+    domain=$(printf -- "%s" "$new_domain_name" | tr -d -c 'a-zA-Z0-9.-')
     search=$(printf -- "%s" "$new_dhcp6_domain_search" | tr -d '[:cntrl:]')
     namesrv=$new_dhcp6_name_servers
     hostname=$(printf '%s' "$new_host_name" | tr -d -c 'a-zA-Z0-9.-')

--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -14,8 +14,6 @@ setup_interface() {
     mask=$new_subnet_mask
     bcast=$new_broadcast_address
     gw=${new_routers%%,*}
-    # get rid of control chars and anything else that is unsafe in
-    # generated shell snippets (/tmp/net.$netif.hostname is sourced later)
     domain=$(printf -- "%s" "$new_domain_name" | tr -d -c 'a-zA-Z0-9.-')
     search=$(printf -- "%s" "$new_domain_search" | tr -d '[:cntrl:]')
     namesrv=$new_domain_name_servers
@@ -89,8 +87,6 @@ setup_interface() {
 }
 
 setup_interface6() {
-    # get rid of control chars and anything else that is unsafe in
-    # generated shell snippets (/tmp/net.$netif.hostname is sourced later)
     domain=$(printf -- "%s" "$new_domain_name" | tr -d -c 'a-zA-Z0-9.-')
     search=$(printf -- "%s" "$new_dhcp6_domain_search" | tr -d '[:cntrl:]')
     namesrv=$new_dhcp6_name_servers


### PR DESCRIPTION
## Problem

`modules.d/35network-legacy/dhclient-script.sh` sanitizes the DHCP-supplied `hostname` strictly (`tr -d -c 'a-zA-Z0-9.-'`, from #2470 / 11577739) — but the sibling `domain` (DHCP option 15 / DHCPv6 domain-search) only got `tr -d '[:cntrl:]'`.

`domain` is embedded **inside single quotes** when generating the hostname file, in both `setup_interface()` and `setup_interface6()`:

```sh
[ -n "$hostname" ] && echo "echo '${hostname%."$domain"}${domain:+.$domain}' > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
```

`45net-lib/net-lib.sh` `setup_net()` later **sources** that file as root (line 137). A rogue value escapes the quoting. This is the residual variant of the vector #2470 closed for `hostname`.

## Fix

Restrict `domain` to `[a-zA-Z0-9.-]` — exactly the charset already accepted for `hostname`. RFC 1034/1035 domain labels only need letters, digits, hyphens and dots (and internationalized names arrive as punycode `xn--…`), so no legitimate value changes.

Verified with the **real** `dhclient-script.sh` sourced in a sandbox (`unshare -rmu`, stubbed `ip`/`getarg*` etc.), roaming a hostile DHCP answer:

**Before** (v4 `BOUND` **and** v6 `BOUND6`):
```
--- /tmp/net.eth0.hostname content:
echo 'myhost.ex'; touch /tmp/PWN_H3; #' > /proc/sys/kernel/hostname
RESULT: INJECTED (PWN file created)
```

**After**:
```
echo 'myhost.extouchtmpPWNH3' > /proc/sys/kernel/hostname
RESULT: clean (no PWN file)
```

Benign inputs (`myhost.example.com` / `example.com`) produce byte-identical output before/after.

Harness kept at `/tmp/opencode/h3-baseline.sh`.

## Context

Found while auditing the DHCP input surface of network-legacy (tracker entry H3); H4 (same module, `/etc/teamd` path) is #2605.