### PR TITLE
fix(network-legacy): sanitize more values

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -463,7 +463,8 @@ for p in $(getargs ip=); do
 
     # Store config for later use
     for i in ip srv gw mask hostname macaddr mtu dns1 dns2; do
-        eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
+        eval "_v=\$$i"
+        [ -n "$_v" ] && printf "$i='%s'\n" "$(escape "$_v")"
     done > "/tmp/net.$netif.override"
 
     for autoopt in $(str_replace "$autoconf" "," " "); do

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -193,7 +193,7 @@ do_static() {
         ip addr add "$ip/$mask" ${srv:+peer "$srv"} brd + dev "$netif"
     fi
 
-    [ -n "$gw" ] && echo "ip route replace default via '$gw' dev '$netif'" > "/tmp/net.$netif.gw"
+    [ -n "$gw" ] && printf "ip route replace default via '%s' dev '%s'\n" "$(escape "$gw")" "$(escape "$netif")" > "/tmp/net.$netif.gw"
     [ -n "$hostname" ] && printf "echo '%s' > /proc/sys/kernel/hostname\n" "$(escape "$hostname")" > "/tmp/net.$netif.hostname"
 
     return 0

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -127,7 +127,7 @@ do_ipv6auto() {
     wait_for_ipv6_auto "$netif"
     ret=$?
 
-    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
+    [ -n "$hostname" ] && printf "echo '%s' > /proc/sys/kernel/hostname\n" "$(escape "$hostname")" > "/tmp/net.${netif}.hostname"
 
     return "$ret"
 }
@@ -140,7 +140,7 @@ do_ipv6link() {
     echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
     linkup "$netif"
 
-    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
+    [ -n "$hostname" ] && printf "echo '%s' > /proc/sys/kernel/hostname\n" "$(escape "$hostname")" > "/tmp/net.${netif}.hostname"
 
     return "$ret"
 }
@@ -194,7 +194,7 @@ do_static() {
     fi
 
     [ -n "$gw" ] && echo "ip route replace default via '$gw' dev '$netif'" > "/tmp/net.$netif.gw"
-    [ -n "$hostname" ] && echo "echo '$hostname' > /proc/sys/kernel/hostname" > "/tmp/net.$netif.hostname"
+    [ -n "$hostname" ] && printf "echo '%s' > /proc/sys/kernel/hostname\n" "$(escape "$hostname")" > "/tmp/net.$netif.hostname"
 
     return 0
 }


### PR DESCRIPTION
After seeing #2629, I took another look at #2469, and I realized that we overlooked that https://github.com/dracut-ng/dracut/pull/2469/changes/65f4b4f14564cc1543f27488487a5ba58b9d9470 (or https://github.com/redhat-plumbers/dracut-rhel9/commit/b20496bc5a74e9d7ed15ab1888bc0687741bfa64) also sanitizes values parsed from the kernel command line in ifup.sh.

Added also a fix for `/tmp/net.$netif.override`, which was missing there.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
