### PR TITLE
fix(nvmf): use plain name for upstream udev rules

### DIFF
--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -216,6 +216,6 @@ install() {
     inst_hook cmdline 92 "$moddir/parse-nvmf-boot-connections.sh"
     inst_simple -H "/etc/nvme/discovery.conf"
     inst_simple -H "/etc/nvme/config.json"
-    inst_rules /usr/lib/udev/rules.d/71-nvmf-iopolicy-netapp.rules
+    inst_rules 71-nvmf-iopolicy-netapp.rules
     inst_rules "$moddir/95-nvmf-initqueue.rules"
 }


### PR DESCRIPTION
`inst_rules` automatically scans the udev rules directory, using the full path is unnecessary and will break with `--sysroot`. Found while checking `inst_rules` for #2588.

The change is simple, but there doesn't seem to be an automated test using the nvmf module, so a test from someone who actually uses it might be good.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
