### PR TITLE
test: introduce require_binaries_for_test

### DIFF
--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -8,10 +8,7 @@ TEST_DESCRIPTION="root filesystem on a btrfs filesystem with /usr subvolume"
 #DEBUGFAIL="rd.shell rd.break"
 
 test_check() {
-    if ! type -p mkfs.btrfs &> /dev/null; then
-        echo "Test needs mkfs.btrfs.. Skipping"
-        return 1
-    fi
+    require_binaries_for_test mkfs.btrfs
 }
 
 client_run() {

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -8,10 +8,7 @@ TEST_DESCRIPTION="UEFI boot (ukify, kernel-install)"
 #DEBUGFAIL="rd.debug rd.shell"
 
 test_check() {
-    if ! type -p mksquashfs &> /dev/null; then
-        echo "Test needs mksquashfs... Skipping"
-        return 1
-    fi
+    require_binaries_for_test mksquashfs
 
     local arch=${DRACUT_ARCH:-$(uname -m)}
     if [[ ! ${arch} =~ ^(x86_64|i.86|aarch64|riscv64)$ ]]; then

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -9,15 +9,8 @@ TEST_DESCRIPTION="root filesystem on LVM on encrypted partitions of a RAID"
 #DEBUGFAIL="rd.shell loglevel=70 systemd.log_target=kmsg systemd.log_target=debug"
 
 test_check() {
-    if ! type -p cryptsetup &> /dev/null; then
-        echo "Test needs cryptsetup for crypt module... Skipping"
-        return 1
-    fi
-
-    if ! type -p mdadm &> /dev/null; then
-        echo "Test needs mdadm for mdraid module ... Skipping"
-        return 1
-    fi
+    # cryptsetup needed for crypt module and mdadm for mdraid module
+    require_binaries_for_test cryptsetup mdadm
 }
 
 test_run() {

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -10,10 +10,7 @@ TEST_DESCRIPTION="live root on a squash filesystem"
 #DEBUGFAIL="rd.shell rd.debug rd.live.debug loglevel=7"
 
 test_check() {
-    if ! type -p mksquashfs &> /dev/null; then
-        echo "Test needs mksquashfs... Skipping"
-        return 1
-    fi
+    require_binaries_for_test mksquashfs
 }
 
 client_run() {

--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -8,15 +8,8 @@ TEST_DESCRIPTION="live root provided over network"
 #DEBUGFAIL="rd.shell rd.debug rd.live.debug loglevel=7"
 
 test_check() {
-    if ! type -p mksquashfs &> /dev/null; then
-        echo "Test needs mksquashfs... Skipping"
-        return 1
-    fi
-
-    if ! type -p python3 &> /dev/null; then
-        echo "Test needs python3 as HTTP server... Skipping"
-        return 1
-    fi
+    # python3 needed for HTTP server
+    require_binaries_for_test mksquashfs python3
 }
 
 client_run() {

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -4,7 +4,7 @@ set -eu
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd but without initqueue"
 
 test_check() {
-    command -v systemctl &> /dev/null
+    require_binaries_for_test systemctl
 }
 
 # Uncomment this to debug failures

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -5,12 +5,7 @@ set -eu
 TEST_DESCRIPTION="Full systemd serialization/deserialization test with /usr mount"
 
 test_check() {
-    if ! type -p mkfs.btrfs &> /dev/null; then
-        echo "Test needs mkfs.btrfs.. Skipping"
-        return 1
-    fi
-
-    command -v systemctl &> /dev/null
+    require_binaries_for_test mkfs.btrfs systemctl
 }
 
 # Uncomment this to debug failures

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -5,7 +5,7 @@ set -eu
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd but without dracut-systemd and shell"
 
 test_check() {
-    command -v systemctl &> /dev/null
+    require_binaries_for_test systemctl
 }
 
 # Uncomment this to debug failures

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -7,10 +7,7 @@ TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 #DEBUGFAIL="rd.debug rd.shell"
 
 test_check() {
-    if ! command -v kernel-install > /dev/null; then
-        echo "This test needs kernel-install to run."
-        return 1
-    fi
+    require_binaries_for_test kernel-install
 }
 
 test_run() {

--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -4,15 +4,7 @@ set -eu
 TEST_DESCRIPTION="no (xfs) driver on root filesystem"
 
 test_check() {
-    if ! type -p mkfs.xfs &> /dev/null; then
-        echo "Test needs mkfs.xfs.. Skipping"
-        return 1
-    fi
-
-    if ! command -v systemctl > /dev/null; then
-        echo "This test needs systemd to run."
-        return 1
-    fi
+    require_binaries_for_test mkfs.xfs systemctl
 }
 
 # Uncomment this to debug failures

--- a/test/TEST-45-SYSTEMD-IMPORT/test.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/test.sh
@@ -11,14 +11,7 @@ TEST_DESCRIPTION="download and import disk images at boot with systemd-import"
 IMPORT_VERIFY="checksum"
 
 test_check() {
-    local binary
-
-    for binary in /usr/lib/systemd/systemd-importd systemd-dissect tar zstd; do
-        if ! type -p "$binary" &> /dev/null; then
-            echo "Test needs $binary... Skipping"
-            return 1
-        fi
-    done
+    require_binaries_for_test /usr/lib/systemd/systemd-importd systemd-dissect tar zstd
 }
 
 client_run() {

--- a/test/TEST-46-SYSTEMD-SYSEXT/test.sh
+++ b/test/TEST-46-SYSTEMD-SYSEXT/test.sh
@@ -8,14 +8,7 @@ TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd and extensio
 #DEBUGFAIL="systemd.show_status=1 systemd.log_level=debug"
 
 test_check() {
-    local binary
-
-    for binary in systemd-repart openssl; do
-        if ! type -p "$binary" &> /dev/null; then
-            echo "Test needs $binary... Skipping"
-            return 1
-        fi
-    done
+    require_binaries_for_test systemd-repart openssl
 }
 
 test_run() {

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -7,12 +7,8 @@ set -eu
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 
 test_check() {
-    if ! type -p curl &> /dev/null; then
-        echo "Test needs curl for url-lib... Skipping"
-        return 1
-    fi
-
-    command -v exportfs &> /dev/null
+    # curl needed for url-lib
+    require_binaries_for_test curl exportfs
 }
 
 # Uncomment this to debug failures

--- a/test/TEST-61-CHRONY/test.sh
+++ b/test/TEST-61-CHRONY/test.sh
@@ -14,16 +14,7 @@ FAKE_TIME="2100-01-01T00:00:00"
 SSL_CERT="webserver.pem"
 
 test_check() {
-    local binary
-
-    for binary in chronyd openssl; do
-        if ! type -p "$binary" &> /dev/null; then
-            echo "Test needs $binary... Skipping"
-            return 1
-        fi
-    done
-
-    command -v systemctl &> /dev/null
+    require_binaries_for_test chronyd openssl systemctl
 }
 
 client_run() {

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -117,10 +117,7 @@ test_run() {
 }
 
 test_check() {
-    if ! command -v tgtd &> /dev/null || ! command -v tgtadm &> /dev/null; then
-        echo "Need tgtd and tgtadm from scsi-target-utils"
-        return 1
-    fi
+    require_binaries_for_test tgtadm tgtd
 }
 
 make_client_rootfs() {

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -125,10 +125,7 @@ test_run() {
 }
 
 test_check() {
-    if ! command -v tgtd &> /dev/null || ! command -v tgtadm &> /dev/null; then
-        echo "Need tgtd and tgtadm from scsi-target-utils"
-        return 1
-    fi
+    require_binaries_for_test tgtadm tgtd
 }
 
 make_client_rootfs() {

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -13,12 +13,7 @@ TEST_DESCRIPTION="root filesystem on NBD with $USE_NETWORK"
 #SERIAL="tcp:127.0.0.1:9999"
 
 test_check() {
-    if ! type -p nbd-server &> /dev/null; then
-        echo "Test needs nbd-server... Skipping"
-        return 1
-    fi
-
-    return 0
+    require_binaries_for_test nbd-server
 }
 
 run_server() {

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -12,7 +12,7 @@ test_check() {
         return 1
     fi
 
-    (command -v find && command -v diff) &> /dev/null
+    require_binaries_for_test diff find
 }
 
 cpio_create() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -208,6 +208,15 @@ client_test_end() {
     rm "$TESTDIR/client_test_name.txt"
 }
 
+require_binaries_for_test() {
+    for binary in "$@"; do
+        if ! type -p "$binary" &> /dev/null; then
+            echo "Test needs $binary... Skipping"
+            return 1
+        fi
+    done
+}
+
 # Start a HTTP/HTTPS server that serves the content of TESTDIR
 start_webserver() {
     local pid port type="${1-HTTP}" cert="${2-}"


### PR DESCRIPTION
Reduce code duplication by introducing `require_binaries_for_test` to check for required binaries.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
