### PR TITLE
feat: add extractinitrd and use it in lsinitrd

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,6 +43,10 @@ dracut-util:
     - changed-files:
           - any-glob-to-any-file: 'src/util/*'
 
+extractinitrd:
+    - changed-files:
+          - any-glob-to-any-file: 'src/extractinitrd/*'
+
 skipcpio:
     - changed-files:
           - any-glob-to-any-file: 'src/skipcpio/*'

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -53,6 +53,17 @@ jobs:
                     - "80"
                     - "81"
                     - "82"
+                    - "83"
+                exclude:
+                    # cpio is not installed on Debian/Ubuntu
+                    - container: debian:sid
+                      test: "83"
+                    # cpio is not installed on Debian/Ubuntu
+                    - container: ubuntu:devel
+                      test: "83"
+                    # cpio is not installed on Debian/Ubuntu
+                    - container: ubuntu:rolling
+                      test: "83"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
@@ -98,6 +109,7 @@ jobs:
                     - "80"
                     - "81"
                     - "82"
+                    - "83"
                 exclude:
                     # btrfs kernel module is not available on CentOS Stream 10
                     - container: centos:latest
@@ -141,6 +153,7 @@ jobs:
                     - "80"
                     - "81"
                     - "82"
+                    - "83"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,6 +98,11 @@ jobs:
                     - "50"
                     - "80"
                     - "81"
+                    - "83"
+                exclude:
+                    # cpio is not installed on Debian/Ubuntu
+                    - container: ubuntu:devel
+                      test: "83"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /dracut.conf.d/*.conf
 /dracut.pc
 /src/dracut-cpio/target/
+/src/extractinitrd/extractinitrd
 /src/install/dracut-install
 /src/skipcpio/skipcpio
 /src/util/util

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ manpages = $(man1pages) $(man5pages) $(man7pages) $(man8pages)
 
 .PHONY: install clean distclean archive test all check AUTHORS CONTRIBUTORS doc
 
-all: dracut.pc dracut-install src/skipcpio/skipcpio dracut-util
+all: dracut.pc dracut-install src/extractinitrd/extractinitrd src/skipcpio/skipcpio dracut-util
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(KMOD_CFLAGS) $(SYSTEMD_CFLAGS) $(if $(SYSTEMD_LIBS),-DHAVE_SYSTEMD) $< -o $@
@@ -89,6 +89,9 @@ src/install/dracut-install: $(DRACUT_INSTALL_OBJECTS)
 
 dracut-install: src/install/dracut-install
 	ln -fs $< $@
+
+EXTRACTINITRD_OBJECTS = src/extractinitrd/extractinitrd.o
+src/extractinitrd/extractinitrd: $(EXTRACTINITRD_OBJECTS)
 
 SKIPCPIO_OBJECTS = src/skipcpio/skipcpio.o
 skipcpio/skipcpio.o: src/skipcpio/skipcpio.c
@@ -256,6 +259,9 @@ endif
 	if [ -f src/install/dracut-install ]; then \
 		install -m 0755 src/install/dracut-install $(DESTDIR)$(pkglibdir)/dracut-install; \
 	fi
+	if [ -f src/extractinitrd/extractinitrd ]; then \
+		install -m 0755 src/extractinitrd/extractinitrd $(DESTDIR)$(pkglibdir)/extractinitrd; \
+	fi
 	if [ -f src/skipcpio/skipcpio ]; then \
 		install -m 0755 src/skipcpio/skipcpio $(DESTDIR)$(pkglibdir)/skipcpio; \
 	fi
@@ -298,6 +304,7 @@ clean:
 	$(RM) $(manpages:%=%.xml) dracut.xml
 	$(RM) dracut-*.tar.bz2 dracut-*.tar.xz
 	$(RM) dracut-install src/install/dracut-install $(DRACUT_INSTALL_OBJECTS)
+	$(RM) src/extractinitrd/extractinitrd $(EXTRACTINITRD_OBJECTS)
 	$(RM) src/skipcpio/skipcpio $(SKIPCPIO_OBJECTS)
 	$(RM) dracut-util src/util/util $(UTIL_OBJECTS)
 	$(RM) $(manpages)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ pkglibdir ?= ${libdir}/dracut
 sysconfdir ?= ${prefix}/etc
 bindir ?= ${prefix}/bin
 mandir ?= ${prefix}/share/man
-CFLAGS ?= -O2 -g -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+CFLAGS ?= -O2 -g -Wall -std=gnu11 -D_FILE_OFFSET_BITS=64 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
 bashcompletiondir ?= ${datadir}/bash-completion/completions
 pkgconfigdatadir ?= $(datadir)/pkgconfig
 ARCH ?= $(shell uname -m)

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -96,19 +96,32 @@ while (($# > 0)); do
     shift
 done
 
-CPIO=cpio
+EXTRACTOR=
 if command -v 3cpio > /dev/null; then
     if threecpio_help_output=$(3cpio --help); then
         if [[ $threecpio_help_output == *--make-directories* ]]; then
-            CPIO=3cpio
+            EXTRACTOR=3cpio
         fi
     elif command -v cpio > /dev/null; then
         echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories. Falling back to cpio."
     else
         echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories."
-        CPIO=3cpio
+        EXTRACTOR=3cpio
     fi
     unset threecpio_help_output
+fi
+if ! [[ $EXTRACTOR ]]; then
+    if [[ -f "$dracutbasedir/src/extractinitrd/extractinitrd" ]]; then
+        EXTRACTOR="$dracutbasedir/src/extractinitrd/extractinitrd"
+    else
+        EXTRACTOR="$dracutbasedir/extractinitrd"
+    fi
+    if ! [[ -x $EXTRACTOR ]]; then
+        echo
+        echo "Error: '$EXTRACTOR' not found, cannot continue!" >&2
+        echo
+        exit 1
+    fi
 fi
 
 if ! [[ $KERNEL_VERSION ]]; then
@@ -204,28 +217,28 @@ SQUASH_EXTRACT="$TMPDIR/squash-extract"
 
 # Takes optional pattern arguments
 cpio_extract() {
-    if [ "$CPIO" = 3cpio ]; then
+    if [ "$EXTRACTOR" = 3cpio ]; then
         3cpio --extract --make-directories --parts "$parts" $verbose "$image" -- "$@"
     else
-        $CAT "$image" 2> /dev/null | cpio -id --quiet $verbose -- "$@"
+        "$EXTRACTOR" --parts "$parts" $verbose "$image" -- "$@"
     fi
 }
 
 # Takes optional pattern arguments
 cpio_extract_to_stdout() {
-    if [ "$CPIO" = 3cpio ]; then
+    if [ "$EXTRACTOR" = 3cpio ]; then
         3cpio --extract --parts "$parts" --to-stdout "$image" -- "$@"
     else
-        $CAT "$image" 2> /dev/null | cpio --extract --quiet --to-stdout -- "$@"
+        "$EXTRACTOR" --parts "$parts" --to-stdout "$image" -- "$@"
     fi
 }
 
 # Takes optional pattern arguments
 cpio_list() {
-    if [ "$CPIO" = 3cpio ]; then
+    if [ "$EXTRACTOR" = 3cpio ]; then
         3cpio --list --parts "$parts" --verbose "$image" -- "$@"
     else
-        $CAT "$image" 2> /dev/null | cpio --extract --verbose --quiet --list -- "$@"
+        "$EXTRACTOR" --list --parts "$parts" --verbose "$image" -- "$@"
     fi
 }
 
@@ -439,7 +452,6 @@ unset skip
 read -r -N 6 bin < "$image"
 case $bin in
     $'\x71\xc7'* | 070701)
-        CAT="cat --"
         parts=1
         is_early=$(cpio_extract_to_stdout early_cpio 2> /dev/null)
         # Debian mkinitramfs does not create the file 'early_cpio', so let's check if firmware files exist
@@ -456,80 +468,15 @@ case $bin in
                 echo "Early CPIO image"
                 list_files
             fi
-            if [[ -f "$dracutbasedir/src/skipcpio/skipcpio" ]]; then
-                skip="$dracutbasedir/src/skipcpio/skipcpio"
-            else
-                skip="$dracutbasedir/skipcpio"
-            fi
-            if ! [[ -x $skip ]]; then
-                echo
-                echo "'$skip' not found, cannot display remaining contents!" >&2
-                echo
-                exit 0
-            fi
+            parts=2-
+        else
+            parts=1-
         fi
-        ;;
-esac
-
-if [[ $skip ]]; then
-    bin="$($skip "$image" | { read -r -N 6 bin && echo "$bin"; })"
-else
-    read -r -N 6 bin < "$image"
-fi
-case $bin in
-    $'\x1f\x8b'*)
-        CAT="zcat --"
-        ;;
-    BZh*)
-        CAT="bzcat --"
-        ;;
-    $'\x71\xc7'* | 070701)
-        CAT="cat --"
-        ;;
-    $'\x02\x21'*)
-        CAT="lz4 -d -c"
-        ;;
-    $'\x89'LZO$'\0'*)
-        CAT="lzop -d -c"
-        ;;
-    $'\x28\xB5\x2F\xFD'*)
-        CAT="zstd -d -c"
         ;;
     *)
-        if echo "test" | xz | xzcat --single-stream > /dev/null 2>&1; then
-            CAT="xzcat --single-stream --"
-        else
-            CAT="xzcat --"
-        fi
+        parts=1-
         ;;
 esac
-
-type "${CAT%% *}" > /dev/null 2>&1 || {
-    echo "Need '${CAT%% *}' to unpack the initramfs."
-    exit 1
-}
-
-# shellcheck disable=SC2317,SC2329  # assigned to CAT and $CAT called later
-skipcpio() {
-    $skip "$@" | $ORIG_CAT
-}
-
-parts="1-"
-if [[ $skip ]]; then
-    ORIG_CAT="$CAT"
-    CAT=skipcpio
-    parts="2-"
-fi
-
-if ((${#filenames[@]} > 1)); then
-    TMPFILE="$TMPDIR/initrd.cpio"
-    $CAT "$image" 2> /dev/null > "$TMPFILE"
-    # shellcheck disable=SC2317,SC2329  # assigned to CAT and $CAT called later
-    pre_decompress() {
-        cat "$TMPFILE"
-    }
-    CAT=pre_decompress
-fi
 
 ret=0
 

--- a/src/extractinitrd/extractinitrd.c
+++ b/src/extractinitrd/extractinitrd.c
@@ -1,0 +1,794 @@
+/* extractinitrd.c
+
+   This program is derived from Debian initramfs-tools' unmkinitramfs.
+
+   Copyright (C) 2025-2026 Ben Hutchings <benh@debian.org>
+   Copyright (C) 2025-2026 Benjamin Drung <benjamin.drung@canonical.com>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* extractinitrd: Unpack an initramfs */
+
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <err.h>
+#include <getopt.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ * The "new" cpio header supported by the kernel.  All fields after
+ * magic hold 32-bit values in hexadecimal.  This is immediately
+ * followed by the name, then contents.
+ */
+struct cpio_new {
+        char c_magic[6];
+        char c_ino[8];
+        char c_mode[8];
+        char c_uid[8];
+        char c_gid[8];
+        char c_nlink[8];
+        char c_mtime[8];
+        char c_filesize[8];
+        char c_dev_maj[8];
+        char c_dev_min[8];
+        char c_rdev_maj[8];
+        char c_rdev_min[8];
+        char c_namesize[8];
+        char c_chksum[8];
+} __attribute__((packed));
+
+#define CPIO_NEW_MAGIC     "070701"
+#define CPIO_NEW_CRC_MAGIC "070702"
+#define CPIO_MAGIC_LEN     6
+
+/* Name of the last entry in a cpio archive */
+#define CPIO_NAME_TRAILER "TRAILER!!!"
+
+struct cpio_entry {
+        const char *name;
+        off_t      start, end;
+};
+
+struct cpio_handle {
+        FILE       *file;
+        const char *name;
+        off_t      next_off;
+        char       name_buf[PATH_MAX];
+};
+
+struct cpio_proc {
+        int pid;
+        int pipe;
+};
+
+enum format {
+        FORMAT_CPIO_NEW,
+        FORMAT_GZIP,
+        FORMAT_BZIP2,
+        FORMAT_LZMA,
+        FORMAT_XZ,
+        FORMAT_LZO,
+        FORMAT_LZ4,
+        FORMAT_ZSTD,
+};
+
+#define MAX_MAGIC_LEN 12
+
+struct magic_entry {
+        unsigned int  magic_len;
+        unsigned char magic[MAX_MAGIC_LEN];
+        enum format   format;
+};
+
+#define MAGIC_ENTRY(magic, format) { sizeof(magic) - 1, magic, format }
+
+static const struct magic_entry magic_table[] = {
+        MAGIC_ENTRY(CPIO_NEW_MAGIC,        FORMAT_CPIO_NEW),
+        MAGIC_ENTRY(CPIO_NEW_CRC_MAGIC,    FORMAT_CPIO_NEW),
+        MAGIC_ENTRY("\x1f\x8b\x08",        FORMAT_GZIP),
+        MAGIC_ENTRY("BZh",                 FORMAT_BZIP2),
+        MAGIC_ENTRY("\x5d\0\0",            FORMAT_LZMA),
+        MAGIC_ENTRY("\xfd""7zXZ\0",        FORMAT_XZ),
+        MAGIC_ENTRY("\x89LZO\0\r\n\x1a\n", FORMAT_LZO),
+        /* lz4 "legacy" format, the only version that the kernel supports */
+        MAGIC_ENTRY("\x02\x21\x4c\x18",    FORMAT_LZ4),
+        MAGIC_ENTRY("\x28\xb5\x2f\xfd",    FORMAT_ZSTD),
+        { 0 }
+};
+
+static const char *const decomp_table[][2] = {
+        [FORMAT_GZIP] =  { "gzip", "-cd" },
+        [FORMAT_BZIP2] = { "bzip2", "-cd" },
+        [FORMAT_LZMA] =  { "lzma", "-cd" },
+        [FORMAT_XZ] =    { "xzcat" },
+        [FORMAT_LZO] =   { "lzop", "-cd" },
+        [FORMAT_LZ4] =   { "lz4cat" },
+        [FORMAT_ZSTD] =  { "zstd", "-cdq" },
+};
+
+struct part_range {
+        unsigned long start;
+        unsigned long end;
+};
+
+/* Parse single range options: "N", "N-M", "N-", or "-M" */
+static struct part_range *parse_parts(const char *spec)
+{
+        char *endptr;
+        unsigned long start = 1;
+        unsigned long end = SIZE_MAX;
+
+        if (isdigit((unsigned char)*spec)) {
+                start = strtoul(spec, &endptr, 10);
+                if (start == 0)
+                        return NULL;
+
+                if (*endptr == '-') {
+                        endptr++;
+                        if (isdigit((unsigned char)endptr[0])) {
+                                end = strtoul(endptr, &endptr, 10);
+                                if (end < start)
+                                        return NULL;
+                        } else if (endptr[0] == '\0') {
+                                end = SIZE_MAX;
+                        } else {
+                                return NULL;
+                        }
+                } else if (*endptr == '\0') {
+                        end = start;
+                } else {
+                        return NULL;
+                }
+        } else if (*spec == '-') {
+                if (!isdigit((unsigned char)spec[1]))
+                        return NULL;
+                end = strtoul(spec + 1, &endptr, 10);
+                if (end == 0)
+                        return NULL;
+        } else {
+                return NULL;
+        }
+
+        if (*endptr != '\0')
+                return NULL;
+
+        struct part_range *range = malloc(sizeof(*range));
+        if (!range)
+                return NULL;
+
+        range->start = start;
+        range->end = end;
+        return range;
+}
+
+static bool has_part_exceeded_range(const struct part_range *range, unsigned long part_idx)
+{
+        if (!range)
+                return false;
+        return part_idx > range->end;
+}
+
+static bool is_part_selected(const struct part_range *range, unsigned long part_idx)
+{
+        if (!range)
+                return true;
+        return part_idx >= range->start && part_idx <= range->end;
+}
+
+/* mkdir() but return success if name already exists as directory */
+static bool mkdir_allow_exist(const char *name, mode_t mode)
+{
+        struct stat st;
+        int orig_errno;
+
+        if (mkdir(name, mode) == 0)
+                return true;
+
+        orig_errno = errno;
+        if (orig_errno == EEXIST && stat(name, &st) == 0 && S_ISDIR(st.st_mode))
+                return true;
+
+        errno = orig_errno;
+        return false;
+}
+
+/* write() with loop in case of partial writes */
+static bool write_all(int fd, const void *buf, size_t len)
+{
+        size_t pos;
+        ssize_t ret;
+
+        pos = 0;
+        do {
+                ret = write(fd, (const char *)buf + pos, len - pos);
+                if (ret < 0)
+                        return false;
+                pos += ret;
+        } while (pos < len);
+
+        return true;
+}
+
+/*
+ * Warn about failure of fread.  This may be due to a file error
+ * reported in errno, or EOF which is not.
+ */
+static void warn_after_fread_failure(FILE *file, const char *name)
+{
+        if (ferror(file))
+                warn("%s", name);
+        else
+                warnx("%s: unexpected EOF", name);
+}
+
+/*
+ * Parse one of the hexadecimal fields.  Don't use strtoul() because
+ * it requires null-termination.
+ */
+static bool cpio_parse_hex(const char *field, uint32_t *value_p)
+{
+        const char digits[] = "0123456789ABCDEF", *p;
+        uint32_t value = 0;
+        unsigned int i;
+        bool found_digit = false;
+
+        /* Skip leading spaces */
+        for (i = 0; i < 8 && field[i] == ' '; ++i)
+                ;
+
+        /* Parse digits up to end of field or null */
+        for (; i < 8 && field[i] != 0; ++i) {
+                p = strchr(digits, (char)toupper((unsigned char)field[i]));
+                if (!p)
+                        return false;
+                value = (value << 4) | (p - digits);
+                found_digit = true;
+        }
+
+        *value_p = value;
+        return found_digit;
+}
+
+/* Align offset of file contents or header */
+static off_t cpio_align(off_t off)
+{
+        return (off + 3) & ~3;
+}
+
+static struct cpio_handle *cpio_open(FILE *file, const char *name)
+{
+        struct cpio_handle *cpio;
+
+        cpio = calloc(1, sizeof(*cpio));
+        if (!cpio)
+                return NULL;
+
+        cpio->file = file;
+        cpio->name = name;
+        cpio->next_off = ftell(file);
+        return cpio;
+}
+
+/*
+ * Read next cpio header and name.
+ * Return:
+ * -1 on error
+ *  0 if entry is trailer
+ *  1 if entry is anything else
+ */
+static int cpio_get_next(struct cpio_handle *cpio, struct cpio_entry *entry)
+{
+        struct cpio_new header;
+        uint32_t file_size, name_size;
+
+        if (fseek(cpio->file, cpio->next_off, SEEK_SET) < 0 ||
+            fread(&header, sizeof(header), 1, cpio->file) != 1) {
+                warn_after_fread_failure(cpio->file, cpio->name);
+                return -1;
+        }
+
+        if ((memcmp(header.c_magic, CPIO_NEW_MAGIC, CPIO_MAGIC_LEN) != 0 &&
+             memcmp(header.c_magic, CPIO_NEW_CRC_MAGIC, CPIO_MAGIC_LEN) != 0) ||
+            !cpio_parse_hex(header.c_filesize, &file_size) ||
+            !cpio_parse_hex(header.c_namesize, &name_size)) {
+                warnx("%s: cpio archive has invalid header", cpio->name);
+                return -1;
+        }
+
+        entry->name = cpio->name_buf;
+        entry->start = cpio->next_off;
+
+        /* Calculate offset of the next header */
+        uint32_t header_size = cpio_align(cpio->next_off + sizeof(header) + name_size);
+        cpio->next_off = cpio_align(header_size + file_size);
+        entry->end = cpio->next_off;
+
+        if (name_size > sizeof(cpio->name_buf)) {
+                warnx("%s: cpio member name is too long", cpio->name);
+                return -1;
+        }
+
+        if (fread(cpio->name_buf, name_size, 1, cpio->file) != 1) {
+                warn_after_fread_failure(cpio->file, cpio->name);
+                return -1;
+        }
+
+        if (name_size == 0 || cpio->name_buf[name_size - 1] != 0) {
+                warnx("%s: cpio member name is invalid", cpio->name);
+                return -1;
+        }
+
+        return strcmp(entry->name, CPIO_NAME_TRAILER) != 0;
+}
+
+static void cpio_close(struct cpio_handle *cpio)
+{
+        free(cpio);
+}
+
+static bool copy_to_pipe(FILE *in_file, const char *in_filename,
+                         off_t start, off_t end, int out_pipe)
+{
+        char buf[0x10000];
+        off_t in_pos;
+        size_t want_len, read_len;
+
+        /* Set input position */
+        fseek(in_file, start, SEEK_SET);
+        in_pos = start;
+
+        while (in_pos < end) {
+                /* How much do we want to copy? */
+                want_len = sizeof(buf);
+                if ((ssize_t)want_len > end - in_pos)
+                        want_len = end - in_pos;
+
+                /* Read to buffer; update input position */
+                read_len = fread(buf, 1, want_len, in_file);
+                if (!read_len) {
+                        warn_after_fread_failure(in_file, in_filename);
+                        return false;
+                }
+                in_pos += read_len;
+
+                /* Write to pipe */
+                if (!write_all(out_pipe, buf, read_len)) {
+                        warn("pipe write");
+                        return false;
+                }
+        }
+
+        return true;
+}
+
+static bool handle_uncompressed(FILE *in_file, const char *in_filename,
+                                int out_pipe, bool extract)
+{
+        struct cpio_handle *cpio;
+        struct cpio_entry entry;
+        uint32_t pad;
+        int ret;
+
+        cpio = cpio_open(in_file, in_filename);
+        if (!cpio)
+                return false;
+
+        while ((ret = cpio_get_next(cpio, &entry)) > 0) {
+                if (extract && !copy_to_pipe(in_file, in_filename,
+                                             entry.start, entry.end, out_pipe)) {
+                        ret = -1;
+                        break;
+                }
+        }
+
+        cpio_close(cpio);
+
+        if (ret < 0)
+                return false;
+
+        /* Skip trailer and any zero padding */
+        fseek(in_file, entry.end, SEEK_SET);
+        while (fread(&pad, sizeof(pad), 1, in_file)) {
+                if (pad != 0) {
+                        fseek(in_file, -sizeof(pad), SEEK_CUR);
+                        break;
+                }
+        }
+
+        return true;
+}
+
+static bool handle_compressed(FILE *in_file, enum format format, int out_pipe, bool debug)
+{
+        const char *const *argv = decomp_table[format];
+        int in_fd = fileno(in_file);
+        off_t in_pos = ftell(in_file);
+        int pid, wstatus;
+
+        if (debug)
+                fprintf(stderr, "extractinitrd: Executing %s %s\n", argv[0], argv[1]);
+
+        pid = fork();
+        if (pid < 0)
+                return false;
+
+        /* Child */
+        if (pid == 0) {
+                /*
+                 * Make in_file stdin.  Reset the position of the file
+                 * descriptor because stdio will have read-ahead from
+                 * the position it reported.
+                 */
+                dup2(in_fd, 0);
+                close(in_fd);
+                lseek(0, in_pos, SEEK_SET);
+
+                /* Make out_pipe stdout */
+                dup2(out_pipe, 1);
+                close(out_pipe);
+
+                execlp(argv[0], argv[0], argv[1], NULL);
+                _exit(127);
+        }
+
+        /* Parent: wait for child */
+        if (waitpid(pid, &wstatus, 0) != pid ||
+            !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+                warnx("%s failed", argv[0]);
+                return false;
+        }
+        return true;
+}
+
+static bool write_trailer(int out_pipe)
+{
+        struct {
+                struct cpio_new header;
+                char name[sizeof(CPIO_NAME_TRAILER)];
+                char pad[-(sizeof(struct cpio_new) + sizeof(CPIO_NAME_TRAILER)) & 3];
+        } __attribute__((packed)) trailer;
+        char name_size[8 + 1];
+
+        static_assert((sizeof(trailer) & 3) == 0, "pad miscalculated");
+
+        memset(&trailer.header, '0', sizeof(trailer.header));
+        memcpy(trailer.header.c_magic, CPIO_NEW_MAGIC, CPIO_MAGIC_LEN);
+        sprintf(name_size, "%08zX", sizeof(CPIO_NAME_TRAILER));
+        memcpy(trailer.header.c_namesize, name_size,
+               sizeof(trailer.header.c_namesize));
+
+        strcpy(trailer.name, CPIO_NAME_TRAILER);
+
+        memset(&trailer.pad, 0, sizeof(trailer.pad));
+
+        if (!write_all(out_pipe, &trailer, sizeof(trailer))) {
+                warn("pipe write");
+                return false;
+        }
+
+        return true;
+}
+
+static bool spawn_cpio(int optc, const char **optv, const char *dirname,
+                       bool to_stdout, bool debug, struct cpio_proc *proc)
+{
+        const char *argv[optc + 5];
+        int pipe_fds[2], pid;
+        size_t argc;
+
+        /* Combine base cpio command with extra options */
+        argc = 0;
+        argv[argc++] = "cpio";
+        argv[argc++] = "-i";
+        argv[argc++] = "--quiet";
+        if (to_stdout)
+                argv[argc++] = "--to-stdout";
+        else
+                argv[argc++] = "-m";
+        while (optc--)
+                argv[argc++] = *optv++;
+        argv[argc] = NULL;
+
+        if (debug) {
+                fprintf(stderr, "extractinitrd: Executing");
+                for (size_t i = 0; argv[i] != NULL; i++)
+                        fprintf(stderr, " %s", argv[i]);
+                if (dirname)
+                        fprintf(stderr, " (in directory: %s)", dirname);
+                fprintf(stderr, "\n");
+        }
+
+        if (pipe(pipe_fds)) {
+                warn("pipe");
+                return false;
+        }
+        pid = fork();
+        if (pid < 0) {
+                warn("fork");
+                return false;
+        }
+
+        /* Child */
+        if (pid == 0) {
+                if (dirname && chdir(dirname))
+                        _exit(127);
+
+                /*
+                 * Close write end of the pipe; make the read end
+                 * stdout.
+                 */
+                close(pipe_fds[1]);
+                dup2(pipe_fds[0], 0);
+                close(pipe_fds[0]);
+
+                execvp("cpio", (char **)argv);
+                _exit(127);
+        }
+
+        /*
+         * Parent: close read end of the pipe; return child pid and
+         * write end of pipe.
+         */
+        close(pipe_fds[0]);
+        proc->pid = pid;
+        proc->pipe = pipe_fds[1];
+        return true;
+}
+
+static bool end_cpio(const struct cpio_proc *proc, bool ok)
+{
+        int wstatus;
+
+        close(proc->pipe);
+
+        if (ok) {
+                if (waitpid(proc->pid, &wstatus, 0) != proc->pid ||
+                    !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+                        warnx("cpio failed");
+                        return false;
+                }
+        } else {
+                kill(proc->pid, SIGTERM);
+        }
+
+        return true;
+}
+
+// Run cpio --help and check if --no-absolute-filenames is listed
+// Assume existing support in case of failure.
+static bool cpio_supports_no_absolute_filenames(void)
+{
+        int pipe_fds[2];
+        if (pipe(pipe_fds) != 0)
+                return true;
+
+        pid_t pid = fork();
+        if (pid < 0) {
+                close(pipe_fds[0]);
+                close(pipe_fds[1]);
+                return true;
+        }
+
+        if (pid == 0) {
+                close(pipe_fds[0]);
+                dup2(pipe_fds[1], STDOUT_FILENO);
+                dup2(pipe_fds[1], STDERR_FILENO);
+                close(pipe_fds[1]);
+                execlp("cpio", "cpio", "--help", NULL);
+                _exit(127);
+        }
+
+        close(pipe_fds[1]);
+        char buf[1024];
+        ssize_t n;
+        bool found = false;
+
+        while ((n = read(pipe_fds[0], buf, sizeof(buf) - 1)) > 0) {
+                buf[n] = '\0';
+                if (strstr(buf, "--no-absolute-filenames") != NULL) {
+                        found = true;
+                        break;
+                }
+        }
+
+        close(pipe_fds[0]);
+        waitpid(pid, NULL, 0);
+        return found;
+}
+
+static const struct option long_opts[] = {
+        { "help",          no_argument,       NULL, 'h' },
+        { "list",          no_argument,       NULL, 'l' },
+        { "parts",         required_argument, NULL, 'P' },
+        { "verbose",       no_argument,       NULL, 'v' },
+        { "to-stdout",     no_argument,       NULL, 's' },
+        { "directory",     required_argument, NULL, 'D' },
+        { "debug",         no_argument,       NULL, 'd' },
+        { NULL,            0,                 NULL, 0 }
+};
+
+static void usage(FILE *stream)
+{
+        fprintf(stream, "\
+\n\
+Usage: extractinitrd [-l|--list] [-P|--parts RANGE] [--to-stdout] [-D|--directory DIR]\n\
+                     [-v|--verbose] [--debug] INITRD [PATTERN...]\n\
+\n\
+Options:\n\
+  -l, --list           List the contents of the cpio archives\n\
+  -P, --parts RANGE    Only operate on specified cpio archive range (e.g. 1, 1-3, 2-, -2)\n\
+  --to-stdout          Extract files to standard output\n\
+  -D, --directory DIR  Change to directory DIR before extracting\n\
+  -v, --verbose        Display verbose messages about extraction\n\
+  --debug              Print debugging information\n\
+\n"
+               );
+}
+
+int main(int argc, char **argv)
+{
+        int opt;
+        bool do_list = false;
+        bool verbose = false;
+        bool to_stdout = false;
+        bool debug = false;
+        const char *out_dirname = NULL;
+        struct part_range *range = NULL;
+        const char *in_filename;
+        FILE *in_file;
+        const char *cpio_optv[argc];
+        int cpio_optc = 0;
+        struct cpio_proc cpio_proc = { 0 };
+        bool ok = true;
+
+        /* Parse options */
+        opterr = 0;
+        while ((opt = getopt_long(argc, argv, "hlP:vD:s", long_opts, NULL)) >= 0) {
+                switch (opt) {
+                case '?':
+                        usage(stderr);
+                        return 2;
+                case 'h':
+                        usage(stdout);
+                        return 0;
+                case 'l':
+                        do_list = true;
+                        break;
+                case 'P':
+                        range = parse_parts(optarg);
+                        if (!range)
+                                errx(2, "invalid --parts: '%s'", optarg);
+                        break;
+                case 'v':
+                        verbose = true;
+                        break;
+                case 's':
+                        to_stdout = true;
+                        break;
+                case 'D':
+                        out_dirname = optarg;
+                        break;
+                case 'd':
+                        debug = true;
+                        break;
+                }
+        }
+
+        /* Check number of non-option arguments */
+        if (argc - optind < 1) {
+                usage(stderr);
+                return 2;
+        }
+
+        in_filename = argv[optind];
+        optind++;
+
+        /* Set up input file and output directory */
+        in_file = fopen(in_filename, "rb");
+        if (!in_file)
+                err(1, "%s", in_filename);
+        if (out_dirname != NULL) {
+                if (!mkdir_allow_exist(out_dirname, 0777))
+                        err(1, "%s", out_dirname);
+        }
+
+        /* Spawn cpio with appropriate options and pipe */
+        if (do_list)
+                cpio_optv[cpio_optc++] = "-t";
+        if (verbose)
+                cpio_optv[cpio_optc++] = "-v";
+        if (!do_list && !to_stdout && cpio_supports_no_absolute_filenames())
+                cpio_optv[cpio_optc++] = "--no-absolute-filenames";
+        while (optind < argc)
+                cpio_optv[cpio_optc++] = argv[optind++];
+
+        if (!spawn_cpio(cpio_optc, cpio_optv, out_dirname, to_stdout, debug, &cpio_proc))
+                return 1;
+
+        /* Iterate over archives within the initramfs */
+        for (unsigned long current_part = 1; ; current_part++) {
+                unsigned char magic_buf[MAX_MAGIC_LEN];
+                size_t read_len;
+                const struct magic_entry *me;
+
+                if (has_part_exceeded_range(range, current_part)) {
+                        if (!write_trailer(cpio_proc.pipe))
+                                ok = false;
+                        break;
+                }
+
+                /* Peek at first bytes of next archive; handle EOF */
+                read_len = fread(magic_buf, 1, sizeof(magic_buf), in_file);
+                if (read_len == 0) {
+                        /*
+                         * EOF with no compressed archive. Add back a
+                         * trailer to keep cpio happy.
+                         */
+                        if (ferror(in_file)) {
+                                warn("%s", in_filename);
+                                ok = false;
+                        }
+                        if (!write_trailer(cpio_proc.pipe))
+                                ok = false;
+                        break;
+                }
+                fseek(in_file, -(long)read_len, SEEK_CUR);
+
+                /* Identify format */
+                for (me = magic_table; me->magic_len; ++me)
+                        if (read_len >= me->magic_len &&
+                            memcmp(magic_buf, me->magic, me->magic_len) == 0)
+                                break;
+                if (me->magic_len == 0) {
+                        warnx("%s: unrecognised compression or corrupted file",
+                              in_filename);
+                        ok = false;
+                        break;
+                }
+
+                bool selected = is_part_selected(range, current_part);
+
+                if (me->format == FORMAT_CPIO_NEW) {
+                        ok = handle_uncompressed(in_file, in_filename,
+                                                 cpio_proc.pipe, selected);
+                        if (!ok)
+                                break;
+                } else {
+                        if (selected) {
+                                ok = handle_compressed(in_file, me->format,
+                                                       cpio_proc.pipe, debug);
+                        }
+                        break;
+                }
+        }
+
+        fclose(in_file);
+        free(range);
+
+        if (!end_cpio(&cpio_proc, ok))
+                ok = false;
+
+        return !ok;
+}

--- a/test/TEST-83-EXRACTINITRD/Makefile
+++ b/test/TEST-83-EXRACTINITRD/Makefile
@@ -1,0 +1,1 @@
+-include ../Makefile.testdir

--- a/test/TEST-83-EXRACTINITRD/test.sh
+++ b/test/TEST-83-EXRACTINITRD/test.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+set -eu
+
+# shellcheck disable=SC2034
+TEST_DESCRIPTION="test extractinitrd"
+
+# Uncomment this to debug failures
+#DEBUG="1"
+
+test_check() {
+    require_binaries_for_test cpio diff find gzip
+}
+
+get_extractinitrd_cmd() {
+    if [ "$PKGLIBDIR" = "$basedir" ]; then
+        echo "${PKGLIBDIR}/src/extractinitrd/extractinitrd"
+    else
+        echo "${PKGLIBDIR}/extractinitrd"
+    fi
+}
+
+# Dummy compressor; wrapper for cat that ignores its argument (-c)
+# shellcheck disable=SC2329
+no_compressor() {
+    # shellcheck disable=SC2317
+    cat
+}
+
+make_one_archive() {
+    local type="$1"
+    local i="$2"
+    local dir_name
+    local j
+
+    case "$type" in
+        early)
+            dir_name="kernel/dir$i"
+            ;;
+        main)
+            dir_name="dir$i"
+            ;;
+        *)
+            echo >&2 "E: Bad archive type $type"
+            exit 1
+            ;;
+    esac
+
+    mkdir -p "$TESTDIR/input/$type$i/$dir_name"
+    for j in $(seq 0 9); do
+        size=$((j * 987 + i * 654 + 321))
+        dd if=/dev/urandom of="$TESTDIR/input/$type$i/$dir_name/file$j" \
+            bs="$size" count=1 status=none
+    done
+    echo "$type$i" > "$TESTDIR/input/$type$i/$dir_name/metadata"
+    (
+        cd "$TESTDIR/input/$type$i"
+        find . -print0 | sort -z | cpio -o --null --quiet -H newc > ../"$type$i.cpio"
+    )
+}
+
+construct_initrd_image() {
+    local n_early="$1"
+    local n_main="$2"
+    local compressor="$3"
+
+    # BusyBox lzma only supports extraction.
+    if [ "$compressor" = "lzma" ] && ! lzma --help 2>&1 | grep -qwi "compress"; then
+        compressor="xz --format=lzma"
+    fi
+
+    : > "$TESTDIR/initrd.img"
+    for i in $(seq 0 $((n_early - 1))); do
+        cat "$TESTDIR/input/early$i.cpio" >> "$TESTDIR/initrd.img"
+    done
+    for i in $(seq 0 $((n_main - 2))); do
+        cat "$TESTDIR/input/main$i.cpio" >> "$TESTDIR/initrd.img"
+    done
+    if [ "$n_main" -ge 1 ]; then
+        $compressor -c < "$TESTDIR/input/main$((n_main - 1)).cpio" \
+            >> "$TESTDIR/initrd.img"
+    fi
+}
+
+verify_extraction() {
+    local n_early="$1"
+    local n_main="$2"
+
+    # Construct what we expect output to look like
+    rm -rf "$TESTDIR/reference"
+    mkdir "$TESTDIR/reference"
+    for i in $(seq 0 $((n_early - 1))); do
+        mkdir -p "$TESTDIR/reference/kernel"
+        ln -s ../../input/"early$i/kernel/dir$i" "$TESTDIR/reference/kernel/"
+    done
+    for i in $(seq 0 $((n_main - 1))); do
+        ln -s ../input/"main$i/dir$i" "$TESTDIR/reference/"
+    done
+
+    # Compare reference and output
+    diff -r "$TESTDIR/reference" "$TESTDIR/output" || {
+        echo >&2 'E: Output files do not match input'
+        return 1
+    }
+}
+
+# Test extracting the full initrd with all cpio parts in all combinations.
+test_full_extraction() {
+    local compressor="$1"
+    # Test up to 2 early and 2 main cpio archives, and all supported
+    # compressors (including none) for the last main archive
+    for n_early in 0 1 2; do
+        for n_main in 0 1 2; do
+            # There must be at least 1 archive
+            if [ $((n_early + n_main)) -eq 0 ]; then
+                continue
+            fi
+            # If last archive is early, it can't be compressed
+            if [ $n_main -eq 0 ] && [ "$compressor" != no_compressor ]; then
+                continue
+            fi
+
+            echo "I: Testing full extraction on initrd with $n_early early + $n_main main archive(s) with $compressor"
+            construct_initrd_image "$n_early" "$n_main" "$compressor"
+
+            # Unpack it
+            rm -rf "$TESTDIR/output"
+            $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
+                echo >&2 'E: extractinitrd failed'
+                return 1
+            }
+
+            verify_extraction "$n_early" "$n_main"
+        done
+    done
+}
+
+test_part_extraction() {
+    local compressor="$1"
+
+    construct_initrd_image "1" "2" "$compressor"
+
+    echo "I: Testing extracting part 1 of initrd with $compressor"
+    rm -rf "$TESTDIR/output"
+    $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
+        echo >&2 'E: extractinitrd failed'
+        return 1
+    }
+    verify_extraction 1 0
+
+    echo "I: Testing extracting part 2 of initrd with $compressor"
+    rm -rf "$TESTDIR/output"
+    $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
+        echo >&2 'E: extractinitrd failed'
+        return 1
+    }
+    verify_extraction 0 1
+
+    echo "I: Testing extracting everything except part 1 of initrd with $compressor"
+    rm -rf "$TESTDIR/output"
+    $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
+        echo >&2 'E: extractinitrd failed'
+        return 1
+    }
+    verify_extraction 0 2
+}
+
+assert_equal() {
+    local got="$1"
+    local expected="$2"
+
+    if [ "$got" != "$expected" ]; then
+        echo "E: '$got' does not match '$expected'" >&2
+        return 1
+    fi
+}
+
+test_extract_to_stdout() {
+    local compressor="$1"
+
+    construct_initrd_image "2" "2" "$compressor"
+
+    echo "I: Testing pattern does not match anything of initrd with $compressor"
+    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --to-stdout \
+        "$TESTDIR/initrd.img" -- non-existing)
+    assert_equal "$metadata" ''
+
+    echo "I: Testing extracting early 1 metadata of initrd with $compressor"
+    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --to-stdout \
+        "$TESTDIR/initrd.img" -- kernel/dir0/metadata)
+    assert_equal "$metadata" 'early0'
+
+    echo "I: Testing extracting two metadata files of initrd with $compressor"
+    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --to-stdout \
+        "$TESTDIR/initrd.img" -- kernel/dir1/metadata dir0/metadata)
+    assert_equal "$metadata" $'early1\nmain0'
+}
+
+test_list() {
+    local compressor="$1"
+
+    construct_initrd_image "1" "2" "$compressor"
+
+    echo "I: Testing list full content of initrd with $compressor"
+    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
+    assert_equal "$metadata" '.
+kernel
+kernel/dir0
+kernel/dir0/file0
+kernel/dir0/file1
+kernel/dir0/file2
+kernel/dir0/file3
+kernel/dir0/file4
+kernel/dir0/file5
+kernel/dir0/file6
+kernel/dir0/file7
+kernel/dir0/file8
+kernel/dir0/file9
+kernel/dir0/metadata
+.
+dir0
+dir0/file0
+dir0/file1
+dir0/file2
+dir0/file3
+dir0/file4
+dir0/file5
+dir0/file6
+dir0/file7
+dir0/file8
+dir0/file9
+dir0/metadata
+.
+dir1
+dir1/file0
+dir1/file1
+dir1/file2
+dir1/file3
+dir1/file4
+dir1/file5
+dir1/file6
+dir1/file7
+dir1/file8
+dir1/file9
+dir1/metadata'
+
+    echo "I: Testing list part 2 of initrd with $compressor"
+    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
+    assert_equal "$metadata" '.
+dir0
+dir0/file0
+dir0/file1
+dir0/file2
+dir0/file3
+dir0/file4
+dir0/file5
+dir0/file6
+dir0/file7
+dir0/file8
+dir0/file9
+dir0/metadata'
+}
+
+test_run() {
+    for compressor in no_compressor gzip bzip2 lzma xz lzop 'lz4 -l' zstd; do
+        if ! command -v "${compressor%% *}" &> /dev/null; then
+            echo "I: Skip testing with '$compressor' because the command is missing." >&2
+            continue
+        fi
+
+        test_full_extraction "$compressor"
+        test_part_extraction "$compressor"
+        test_extract_to_stdout "$compressor"
+        test_list "$compressor"
+    done
+}
+
+test_setup() {
+    # Create input files and archives
+    mkdir "$TESTDIR/input"
+    for in_type in early main; do
+        for i in 0 1 2; do
+            make_one_archive "$in_type" "$i"
+        done
+    done
+}
+
+# shellcheck disable=SC1090
+. "$testdir"/test-functions


### PR DESCRIPTION
Add an `extractinitrd` helper command. This allows simplifying `lsinitrd` and will make `skipcpio` obsolete. The tool is based on `unmkinitramfs` from Debian's initramfs-tools.

This PR is a requisite for https://github.com/dracut-ng/dracut/pull/1433.

This PR is part of a series. There will be a follow-up that changes `dracut-initramfs-restore.sh` to use `extractinitrd` and then `skipcpio` will be removed.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
