### PR TITLE
fix(url-lib): check error if curl fails in subshell

### DIFF
--- a/modules.d/45url-lib/url-lib.sh
+++ b/modules.d/45url-lib/url-lib.sh
@@ -72,10 +72,15 @@ curl_fetch_url() {
         local outdir
         outdir="$(mkuniqdir /tmp curl_fetch_url)"
         (
-            cd "$outdir" || exit
+            cd "$outdir" || exit $?
             # shellcheck disable=SC2086
-            curl $curl_args --remote-name "$url" || return $?
+            curl $curl_args --remote-name "$url"
         )
+        local ret=$?
+        if [ "$ret" -ne 0 ]; then
+            rm -rf -- "$outdir"
+            return $ret
+        fi
         outloc="$outdir/$(ls -A "$outdir")"
     fi
     if ! [ -f "$outloc" ]; then
@@ -106,10 +111,15 @@ ctorrent_fetch_url() {
         local outdir
         outdir="$(mkuniqdir /tmp torrent_fetch_url)"
         (
-            cd "$outdir" || exit
+            cd "$outdir" || exit $?
             # shellcheck disable=SC2086
-            curl $curl_args --remote-name "$url" || return $?
+            curl $curl_args --remote-name "$url"
         )
+        local ret=$?
+        if [ "$ret" -ne 0 ]; then
+            rm -rf -- "$outdir"
+            return $ret
+        fi
         torrent_outloc="$outdir/$(ls -A "$outdir")"
         outloc=${torrent_outloc%.*}
     fi


### PR DESCRIPTION
While trying to boot from a live image, I came across a situation where the download was interrupted during the transfer, the image was incomplete, but dracut continued anyway instead of retrying the download:

```
[    1.671687] localhost dracut-cmdline[326]: livenet: root image at http://.../openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
...
[    6.781596] localhost.localdomain dracut-initqueue[892]: ++ outdir=/tmp/curl_fetch_url0
[    6.783194] localhost.localdomain dracut-initqueue[897]: ++ cd /tmp/curl_fetch_url0
[    6.783643] localhost.localdomain dracut-initqueue[897]: ++ curl --globoff --location --retry 3 --retry-connrefused --fail --show-error --remote-name http://...
[    6.789584] localhost.localdomain dracut-initqueue[898]: curl: (18) end of response with 1044480 bytes missing
[    6.793220] localhost.localdomain dracut-initqueue[899]: +++ ls -A /tmp/curl_fetch_url0
[    6.793604] localhost.localdomain dracut-initqueue[892]: ++ outloc=/tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
[    6.793604] localhost.localdomain dracut-initqueue[892]: ++ '[' -f /tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso ']'
[    6.793604] localhost.localdomain dracut-initqueue[892]: ++ echo /tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
[    6.794540] localhost.localdomain dracut-initqueue[875]: + imgfile=/tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
[    6.794540] localhost.localdomain dracut-initqueue[875]: + '[' -n /tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso ']'
[    6.794540] localhost.localdomain dracut-initqueue[875]: + '[' -s /tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso ']'
[    6.794540] localhost.localdomain dracut-initqueue[875]: + root=/tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
[    6.794540] localhost.localdomain dracut-initqueue[875]: + exec /sbin/dmsquash-live-root /tmp/curl_fetch_url0/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
```

The problem is that, in this case, curl leaves the partial file it downloaded, and the only check being done is that there is a file in the output directory, without checking the error code returned by curl in the subshell.

Since we are at it:
- Propagate the error code if the `cd` call fails in the subshell.
- The `|| return $?` is not necessary, the curl exit code will be propagated anyway because is the last call before leaving.
- Partially downloaded files remain in initrd memory for the rest of the boot, so remove the temporary directory on error. Depending on the number of curl failures/retries, this may not be negligible.

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
