### PR TITLE
refactor(dracut-initramfs-restore): inverse if condition order

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -85,14 +85,13 @@ fi
 
 cd /run/initramfs
 
-if extract_initrd "$IMG"; then
-    rm -f -- .need_shutdown
-else
+if ! extract_initrd "$IMG"; then
     # something failed, so we clean up
     echo "Unpacking of $IMG to /run/initramfs failed" >&2
     rm -f -- /run/initramfs/shutdown
     exit 1
 fi
+rm -f -- .need_shutdown
 
 if [[ -f squashfs-root.img ]]; then
     if ! unsquashfs -no-xattrs -f -d . squashfs-root.img > /dev/null; then


### PR DESCRIPTION
Inverse if condition order to make the code more readable.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
