### PR TITLE
fix(dracut): actually register the XFS logdev for host-only builds

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2549,14 +2549,13 @@ done
 for dev in "${!host_fs_types[@]}"; do
     [[ ${host_fs_types[$dev]} == "xfs" ]] || continue
     rootopts=$(find_dev_fsopts "$dev")
-    if [[ ${host_fs_types[$dev]} == "xfs" ]]; then
-        journaldev=$(fs_get_option "$rootopts" "logdev")
-    fi
+    journaldev=$(fs_get_option "$rootopts" "logdev")
     if [[ $journaldev ]]; then
-        dev="$(readlink -f "$dev")"
-        push_host_devs "$dev"
-        _get_fs_type "$dev"
-        check_block_and_slaves_all _get_fs_type "$(get_maj_min "$dev")"
+        journaldev="$(readlink -f "$journaldev")"
+        [[ -b $journaldev ]] || continue
+        push_host_devs "$journaldev"
+        _get_fs_type "$journaldev"
+        check_block_and_slaves_all _get_fs_type "$(get_maj_min "$journaldev")"
     fi
 done
 


### PR DESCRIPTION
## Problem

In `dracut.sh`, the XFS special-case scan of mount options for the root/source mounts does:

```bash
for i in $(find_mp_fsopts "$i"); do
    case $i in
        logdev=* | rtdev=*)
            j="${i#*=}"
            push_host_devs "$j"          # ← re-pushes "$j" resolved from findmnt, not the real journal/block device
            host_fs_types["$j"]=xfs
            ...
```

When the root filesystem is XFS with an **external journal** (`-o logdev=/dev/...`), the option value is captured in `$i`, but the loop re-registers the *same* device node twice instead of resolving and registering the actual journal block device. As a result, in **host-only** builds the external journal device is never added to the host-device list, never checks into `check_block_and_slaves_all`, and no LVM/dm metadata for it is included in the initramfs.

Booting a system whose root is XFS with `logdev=/dev/…` then fails early: the journal disk is not found/activated in the initramfs and the root mount aborts with `Invalid device [/dev/mapper/…]` — falling back to an emergency shell even though the setup is perfectly valid.

## Fix

Resolve the real block device behind `logdev=` (canonicalizing the path, same as elsewhere in the script), and then:

* `push_host_devs "$j"` on the resolved device;
* record `host_fs_types["$j"]`;
* call `check_block_and_slaves_all "$j"` so the journal and all its slaves are walked.

Also `continue` when the resolved node is not a block device so we do not pollute the device list with garbage.

## Testing

* Built host-only initramfs for a KVM guest whose **root is XFS with an external journal on LVM** (`logdev=/dev/mapper/lvmlog-log`).
* *Before:* image had 0 lvm rules, no `rd.lvm.lv` cmdline, boot slams into `XFS (sda): Invalid device [/dev/mapper/lvmlog-log]` → emergency shell.
* *After:* image includes the LVM stack + `root.journaldev=/dev/mapper/lvmlog-log` cmdline; guest mounts the external journal and reaches multi-user/poweroff target. End-to-end boot verified in QEMU/KVM.