### PR TITLE
fix(dracut): ignore empty uefi-splash-image in sysroot builds

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3459,13 +3459,16 @@ if [[ $uefi == yes ]]; then
         unset uefi_cmdline
     fi
 
-    if [[ -s ${dracutsysrootdir-}${uefi_splash_image} ]]; then
-        uefi_splash_image="${dracutsysrootdir-}${uefi_splash_image}"
-        uefi_splash_offs=${offs}
-        offs=$((offs + $(stat -Lc%s "$uefi_splash_image")))
-        offs=$((offs + "$align" - offs % "$align"))
-    else
-        unset uefi_splash_image
+    if [[ $uefi_splash_image ]]; then
+        if [[ -s ${dracutsysrootdir-}${uefi_splash_image} ]]; then
+            uefi_splash_image="${dracutsysrootdir-}${uefi_splash_image}"
+            uefi_splash_offs=${offs}
+            offs=$((offs + $(stat -Lc%s "$uefi_splash_image")))
+            offs=$((offs + "$align" - offs % "$align"))
+        else
+            dfatal "UEFI splash image '$uefi_splash_image' does not exist"
+            exit 1
+        fi
     fi
 
     echo "$SBAT_DEFAULT" > "$sbat_out"


### PR DESCRIPTION
## Problem

During `--sysroot` builds, an empty `uefi_splash_image=` configuration value (e.g. a distro config that sets the key without a value) previously led to an attempt to `stat ''` when a UKI was built.

Conversely, `dracut` always silently ignored a **set but missing** splash image path, which hides real configuration errors.

## Fix

- Empty/unset `uefi_splash_image` → no splash image is added (skip cleanly).
- Set but non-existent path (after `--sysroot` resolution) → hard error (`dfatal`), instead of silently dropping the splash image.

## Verification

Exercised the exact block extracted from `dracut.sh` under `set -u`:

1. empty value → no splash, no error
2. set + missing path → `dracut[F]: UEFI splash image '...' does not exist`, exit 1
3. set + existing path → splash image embedded, offsets computed
4. `--sysroot` path prefixing (`$dracutsysrootdir$uefi_splash_image`) still resolves and errors when the resolved path is missing

`bash -n dracut.sh` clean.
