### PR TITLE
fix(dracut): abort on failed modalias cache generation

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1533,7 +1533,10 @@ dracut_module_path() {
 if [[ ${hostonly-} == "-h" ]] && [[ $no_kernel != yes ]]; then
     if ! [[ $DRACUT_KERNEL_MODALIASES ]] || ! [[ -f $DRACUT_KERNEL_MODALIASES ]]; then
         export DRACUT_KERNEL_MODALIASES="${DRACUT_TMPDIR}/modaliases"
-        $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${srcmods:+--kerneldir "$srcmods"} --modalias > "$DRACUT_KERNEL_MODALIASES"
+        if ! $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${srcmods:+--kerneldir "$srcmods"} --modalias > "$DRACUT_KERNEL_MODALIASES"; then
+            dfatal "Generating the kernel modalias cache failed; cannot continue in host-only mode."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Problem

In host-only mode dracut builds the kernel modalias cache with:

```bash
$DRACUT_INSTALL --modalias > "$DRACUT_KERNEL_MODALIASES"
```

The invocation was not checked. If `dracut-install` fails (module-dir error, bad `--kerneldir`, etc.), the redirect still creates an empty modalias cache file. Downstream host-only module selection then silently sees an empty alias list, so required storage/network modules are not added and the produced initramfs is incomplete — with no error surfaced to the user.

## Fix

Wrap the generation in `if ! …; then … fi` and call `dfatal` + `exit 1` on failure, consistent with other fatal build-time errors in `dracut.sh`.

Manually extracted the block and tested:

* `dracut-install` returning non-zero → fatal message and exit 1 (no bogus cache);
* success → cache file written and build proceeds;
* existing/cache reuse path skips regeneration untouched.
`bash -n dracut.sh` + `make shellcheck` pass.