### PR TITLE
fix(dracut): skip comments and expand persistent names in --add-fstab

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2405,6 +2405,17 @@ done
 for f in $add_fstab; do
     [[ -e $f ]] || continue
     while read -r dev rest || [ -n "$dev" ]; do
+        [[ $dev == \#* ]] && continue
+        [[ $dev ]] || continue
+        dev=$(expand_persistent_dev "$dev")
+        # Canonicalize like the x-initrd.mount scan above does, so the
+        # same device named as /dev/sdX and as UUID=... ends up once in
+        # host_devs.  Unlike that scan we intentionally do NOT skip the
+        # entry when the device is absent now: --add-fstab is an explicit
+        # user request, so the device may show up at boot time; warn
+        # instead of silently dropping it.
+        dev=$(readlink -f "$dev")
+        [[ -b $dev ]] || dwarn "--add-fstab: $dev is not a block device (yet?)"
         push_host_devs "$dev"
     done < "$f"
 done
@@ -2856,6 +2867,7 @@ if [[ $kernel_only != yes ]]; then
     done
 
     for f in $add_fstab; do
+        [[ -e $f ]] || continue
         cat "$f" >> "${initdir}/etc/fstab"
     done
 


### PR DESCRIPTION
## Problem

`--add-fstab` handling in `dracut.sh` scanned the file with a raw `while read -r dev rest` loop and immediately did `push_host_devs "$dev"`. This:

* passes comment lines (`# …`) and empty fields into device collection;
* never resolves `UUID=` / `LABEL=` / `PARTUUID=` / `PARTLABEL=` entries to the real `by-uuid`/`by-label` paths;
* and the separate copy loop `cat "$f" >> "${initdir}/etc/fstab"` was not guarded against a missing file, creating an asymmetric failure mode.

## Fix

* Skip comments and empty `$dev` fields;
* run each device through `expand_persistent_dev()` so persistent names resolve to `/dev/disk/by-*/`;
* add a `[[ -e $f ]] || continue` guard to the copy loop so a missing override fstab is skipped uniformly.

Manually tested with a fstab containing comment/blank lines and a `UUID=…` entry: only real devices are registered, UUID resolves via `expand_persistent_dev`, and a missing file no longer leaks an empty unguarded `cat`.
`bash -n dracut.sh` + `make shellcheck` pass.