### PR TITLE
fix(dracut): honor --no-compress when DRACUT_COMPRESS_CAT is overridden

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1330,7 +1330,7 @@ DRACUT_COMPRESS_ZSTD=${DRACUT_COMPRESS_ZSTD:-zstd}
 DRACUT_COMPRESS_LZ4=${DRACUT_COMPRESS_LZ4:-lz4}
 DRACUT_COMPRESS_CAT=${DRACUT_COMPRESS_CAT:-cat}
 
-if [[ $_no_compress_l == "$DRACUT_COMPRESS_CAT" ]]; then
+if [[ $_no_compress_l == cat ]]; then
     compress="$DRACUT_COMPRESS_CAT"
 fi
 


### PR DESCRIPTION
## Problem

Option parsing sets the no-compress marker to the literal `cat`:

```bash
--no-compress) _no_compress_l="cat" ;;
```

But the decision at the end compares the marker against the `$DRACUT_COMPRESS_CAT` variable (which a config file or environment can redefine):

```bash
if [[ $_no_compress_l == "$DRACUT_COMPRESS_CAT" ]]; then
```

If `DRACUT_COMPRESS_CAT` is anything other than the literal string `cat`, the comparison fails and `--no-compress` is silently ignored — the image is compressed anyway.

## Fix

Compare against the literal marker string `cat` instead of the (overridable) variable. Manual logic test confirms `--no-compress` is now honored regardless of the env override. `bash -n dracut.sh` + `make shellcheck` pass.