### PR TITLE
fix(base): check first argument in load_fstype()

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -1100,8 +1100,9 @@ remove_hostonly_files() {
 # returns OK if kernel_module is loaded
 # modprobe fails if /lib/modules is not available (--no-kernel use case)
 load_fstype() {
-    local - fs _fs="${2:-$1}"
+    local - d fs _fs="${2:-$1}"
     set +x
+    [ -n "$1" ] || return 1
     while read -r d fs || [ "$d" ]; do
         [ "${fs:-$d}" = "$_fs" ] && return 0
     done < /proc/filesystems


### PR DESCRIPTION
`load_fstype()` can receive an empty first argument, specifically from calls in dmsquash-live-root where `det_img_fs()` prints an empty string. That leads to a spurious modprobe error in the log:

```
[    4.428886] localhost.localdomain dracut-initqueue[820]: curl: (18) end of response with 1044480 bytes missing
[    4.515410] localhost.localdomain dracut-initqueue[871]: modprobe: FATAL: Module  not found in directory /usr/lib/modules/7.0.12-1-default
```

Issue found together with #2639.

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
