### PR TITLE
fix(busybox): allow overriding list of applets

### DIFF
--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -791,6 +791,20 @@ _DRACUT_INSTALL_LOG_LEVEL_::
 Default:
     _DRACUT_LOG_LEVEL_
 
+_DRACUT_MODULE_BUSYBOX_LINKS_::
+    overrides the list of busybox applets to link in the initramfs. Used for
+    **--sysroot** if the sysroot is cross-compiled and running `busybox
+    --list-full` is not possible. The list must contain full paths of the links
+    to create (leading slash optional).
++
+If you compile busybox, using the **busybox.links** file produced by the
+busybox build is recommended, e.g.:
++
+`export DRACUT_MODULE_BUSYBOX_LINKS="$(cat busybox.links)"`
++
+Using the output of `busybox --list-full` (e.g. running using Qemu userspace
+emulation) is also possible.
+
 FILES
 -----
 _/var/log/dracut.log_::

--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -15,14 +15,25 @@ check() {
 
 # called by dracut
 install() {
-    local _path _p _busybox _busybox_path
+    local _path _p _busybox _busybox_applets _busybox_path
     local _dstdir="${dstdir:-"$initdir"}"
     local _progs=()
     _busybox=$(find_binary busybox)
     _busybox_path="/usr/bin/busybox"
 
+    # get list of available applets
+    if [[ ${DRACUT_MODULE_BUSYBOX_LINKS-} ]]; then
+        _busybox_applets="$DRACUT_MODULE_BUSYBOX_LINKS"
+    else
+        _busybox_applets="$($_busybox --list-full)"
+    fi
+    if ! [[ ${_busybox_applets} ]]; then
+        derror "Could not get list of busybox applets!"
+        dinfo "If cross-building, try setting DRACUT_MODULE_BUSYBOX_LINKS."
+    fi
+
     # install busybox symlinks manually
-    for _path in $($_busybox --list-full); do
+    for _path in ${_busybox_applets}; do
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names
         if [[ ${_path##*/} == "${_path}" ]]; then

--- a/test/TEST-15-BUSYBOX/test.sh
+++ b/test/TEST-15-BUSYBOX/test.sh
@@ -8,6 +8,12 @@ test_check() {
     require_binaries_for_test busybox
 }
 
+test_setup() {
+    busybox --list-full > "${TESTDIR}/busybox.links"
+    # add an extra link to see if the list is used
+    echo "usr/bin/silly-serval" >> "${TESTDIR}/busybox.links"
+}
+
 check_applets_from_busybox() {
     local _applet _listing ret=0
     local initrd="$1"
@@ -42,7 +48,7 @@ test_run() {
 
     # Check applets the base module would otherwise install from the host.
     # Each must resolve to busybox in the resulting initrd.
-    check_applets_from_busybox "$initrd" cp ip ls mv mkdir sleep tr || ret=1
+    check_applets_from_busybox "$initrd" ash cp ip ls mv mkdir sleep tr || ret=1
 
     # switch_root must NOT be a busybox symlink as the base module reinstalls
     # the host util-linux version on top of any symlink the busybox module left
@@ -50,6 +56,15 @@ test_run() {
         echo "FAIL: switch_root is a busybox symlink, host version was not preserved" >&2
         ret=1
     fi
+
+    # repeat the same test, but override the list of applets
+    rm "$initrd"
+    DRACUT_MODULE_BUSYBOX_LINKS="$(cat "${TESTDIR}/busybox.links")" \
+        test_dracut \
+        --no-hostonly --no-kernel --drivers "" \
+        --modules "base busybox" \
+        "$initrd"
+    check_applets_from_busybox "$initrd" ash cp ip ls mv mkdir silly-serval sleep tr || ret=1
 
     return "$ret"
 }


### PR DESCRIPTION
If the sysroot is cross-compiled, running `busybox --list` is usually not possible. Introduce the environment variable `DRACUT_MODULE_BUSYBOX_LINKS`, which overrides autodetection to work around the problem.

Split out of #2588 as suggest by @devkontrol.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
