### PR TITLE
fix(tests): don't fail a passing test when server teardown races

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -192,10 +192,8 @@ test_nfsv4() {
 }
 
 test_run() {
-    if [[ -s server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    # Kill a leftover server from a previously interrupted run
+    stop_server
 
     if ! run_server; then
         echo "Failed to start server" 1>&2
@@ -205,10 +203,7 @@ test_run() {
     test_nfsv3
     test_nfsv4
 
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    stop_server
 }
 
 make_server_rootfs() {
@@ -272,10 +267,7 @@ test_setup() {
 }
 
 test_cleanup() {
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    stop_server
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -109,10 +109,7 @@ test_run() {
     fi
     do_test_run
     ret=$?
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    stop_server
     return $ret
 }
 
@@ -192,10 +189,7 @@ test_setup() {
 }
 
 test_cleanup() {
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    stop_server
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -117,10 +117,7 @@ test_run() {
     fi
     do_test_run
     ret=$?
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    stop_server
     return $ret
 }
 
@@ -200,10 +197,7 @@ test_setup() {
 }
 
 test_cleanup() {
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
+    stop_server
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -101,7 +101,7 @@ test_run() {
     fi
     client_run
     local res="$?"
-    kill_server
+    stop_server
     return "$res"
 }
 
@@ -159,11 +159,7 @@ client_run() {
     #                52:54:00:12:34:05 \
     #                "root=LABEL=dracut rd.luks.uuid=$ID_FS_UUID rd.lv.vg=dracut netroot=dhcp"
 
-    if [[ -s server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
-
+    stop_server
 }
 
 make_encrypted_rootfs() {
@@ -262,15 +258,8 @@ test_setup() {
         -f "$TESTDIR"/initramfs.server
 }
 
-kill_server() {
-    if [[ -s $TESTDIR/server.pid ]]; then
-        kill -TERM "$(cat "$TESTDIR"/server.pid)"
-        rm -f -- "$TESTDIR"/server.pid
-    fi
-}
-
 test_cleanup() {
-    kill_server
+    stop_server
 }
 
 # shellcheck disable=SC1090

--- a/test/test-functions
+++ b/test/test-functions
@@ -303,6 +303,22 @@ wait_for_server_startup() {
     fi
 }
 
+# Stop the daemonized server QEMU whose pidfile is in $TESTDIR.
+# QEMU removes the pidfile itself when the daemon exits, so the file may
+# already be gone (or hold a dead pid); neither case must fail the test.
+# Only remove the pidfile when the process is already gone, otherwise QEMU
+# deletes it when it exits.
+stop_server() {
+    local server_pid
+    server_pid=$(cat "$TESTDIR"/server.pid 2> /dev/null) || server_pid=
+    [[ -n $server_pid ]] || return 0
+    if ! kill "$server_pid"; then
+        # process already gone, drop the now-stale pidfile
+        rm -f -- "$TESTDIR"/server.pid
+    fi
+    return 0
+}
+
 command -v test_check &> /dev/null || test_check() {
     :
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -205,7 +205,7 @@ client_test_end() {
     [[ -e "$TESTDIR/client_test_name.txt" ]] || return 0
     test_name=$(cat "$TESTDIR/client_test_name.txt")
     echo "CLIENT TEST END: $test_name [$status]"
-    rm "$TESTDIR/client_test_name.txt"
+    rm -f -- "$TESTDIR/client_test_name.txt"
 }
 
 require_binaries_for_test() {
@@ -269,8 +269,8 @@ stop_webserver() {
     if [[ -s "$TESTDIR/webserver.pid" ]]; then
         pid=$(cat "$TESTDIR/webserver.pid")
         echo "Stopping web server (pid $pid)..." >&2
-        kill "$pid"
-        rm "$TESTDIR/webserver.pid"
+        kill "$pid" || true
+        rm -f -- "$TESTDIR/webserver.pid"
     fi
 }
 
@@ -428,7 +428,7 @@ print_test_result() {
     local ret=${1-1}
     if [ "$ret" -eq 0 ]; then
         client_test_end
-        rm -- test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
+        rm -f -- test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
         echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_SUCCESS" "[OK]" "$COLOR_NORMAL"
     else
         client_test_end "FAILED"
@@ -489,15 +489,24 @@ while (($# > 0)); do
                 (
                     test_setup
                     test_run
+                    # teardown is best effort: the daemonized QEMU removes its
+                    # own pidfile on exit, racing the cleanup below; a failure
+                    # there must not turn a passing test into a failure
+                    trap - ERR
+                    set +e
                     test_cleanup
                     test_common_cleanup
+                    exit 0
                 ) 2>&1 | "$tee_command" "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
             else
                 (
                     test_setup
                     test_run
+                    trap - ERR
+                    set +e
                     test_cleanup
                     test_common_cleanup
+                    exit 0
                 ) > test${TEST_RUN_ID:+-$TEST_RUN_ID}.log 2>&1
             fi
             set +o pipefail


### PR DESCRIPTION
## Problem

The integration-test runner arms `trap print_test_result ERR` around the whole `setup`+`run`+`cleanup` subshell, so a failure in the **teardown** phase turns an already-passing test red. The teardown steps are not robust against the daemonized server:

- `qemu -daemonize -pidfile …/server.pid` removes the pidfile itself when the daemon exits, which races the test's `kill`/`rm` cleanup.
- `print_test_result()`'s success path used a bare `rm` of the test log, and `client_test_end()` / `stop_webserver()` used bare `rm` / an unguarded `kill` — each can fail on a file/process that's already gone.

Observed in CI (e.g. TEST-71 on ubuntu:devel) and reproducible locally: all functional boots pass (`All tests passed [OK]`), then a cleanup `rm`/`kill` fails with `No such file or directory` / `No such process`, the ERR trap fires, and the job reports `[FAILED]`.

## Fix

- `test/test-functions`: in the `--all` flow, disable the ERR trap and `set -e` for the best-effort cleanup tail (`trap - ERR; set +e; …; exit 0`) so a teardown race cannot flip a passing test; make the teardown `rm`s `rm -f`; make `stop_webserver`'s `kill` tolerant.
- Add a shared `stop_server()` helper that tolerates the pidfile already being removed (or holding a dead pid) and use it in TEST-60-NFS, TEST-70-ISCSI, TEST-71-ISCSI-MULTI and TEST-72-NBD instead of the duplicated inline blocks.
- This also fixes the leftover-server check in TEST-60-NFS and TEST-72-NBD, which tested `server.pid` relative to the CWD (where it never exists) instead of `$TESTDIR`, so a daemonized server from an interrupted run was never killed before the next one started.

## Verification

- Unit-tested `stop_server()` under `set -eu` for: missing pidfile, empty pidfile, live pid, dead pid, and repeated calls — all return 0.
- Exercised the real `--all` dispatch with the actual `test-functions`: (a) run passes + cleanup races/fails → now `[OK]`/exit 0 (previously `[FAILED]`); (b) run fails → still exactly one `[FAILED]`/exit 1.
- Ran TEST-60-NFS, TEST-70-ISCSI and TEST-71-ISCSI-MULTI in the `ghcr.io/dracut-ng/ubuntu:devel` container with KVM: all three `[OK]`.
- `make syncheck` clean; `bash -n` clean on all touched files.
