### PR TITLE
ci(gentoo): disable Gentoo for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,6 @@ jobs:
                     - arch:latest
                     - debian:latest
                     - fedora:latest
-                    - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
                     - void:latest
@@ -82,7 +81,6 @@ jobs:
                 container:
                     - arch:latest
                     - fedora:latest
-                    - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
                     - void:latest
@@ -127,7 +125,6 @@ jobs:
                 container:
                     - arch:latest
                     - fedora:latest
-                    - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
                 test:


### PR DESCRIPTION
Gentoo will continue to be tested as part of daily testsuite runs.

Workaround for https://github.com/dracut-ng/dracut/issues/2553 .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
