### PR TITLE
feat(opensuse): do not force hostonly_cmdline to yes

### DIFF
--- a/dracut.conf.d/opensuse/01-dist.conf
+++ b/dracut.conf.d/opensuse/01-dist.conf
@@ -5,7 +5,6 @@
 # If you like to build a generic initrd which works on other platforms than
 # on the one dracut got called comment out below setting(s).
 hostonly="yes"
-hostonly_cmdline="yes"
 
 initrdname="initrd-$kernel"
 compress="zstd"


### PR DESCRIPTION
Dracut has a mechanism to disable hostonly_cmdline for chroot and container invocations, but this does not work if distribution configuration forces hostonly_cmdline to be set to yes.

Follow-up to 67d8287 and 1a32e7f .

CC @bdrung @dracut-ng/opensuse-maint 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
