### PR TITLE
fix(busybox): use full path provided by busybox --list-all

### DIFF
--- a/modules.d/81busybox/module-setup.sh
+++ b/modules.d/81busybox/module-setup.sh
@@ -13,26 +13,27 @@ check() {
 
 # called by dracut
 install() {
-    local _i _path _busybox
+    local _path _busybox _busybox_path
     local _dstdir="${dstdir:-"$initdir"}"
     local _progs=()
     _busybox=$(find_binary busybox)
-    inst "$_busybox" /usr/bin/busybox
+    _busybox_path="/usr/bin/busybox"
 
     # do not depend on CONFIG_FEATURE_INSTALLER
     # install busybox symlinks manually
-    for _i in $($_busybox --list); do
-        [[ ${_i} == busybox ]] && continue
-        _progs+=("${_i}")
+    for _path in $($_busybox --list-all); do
+        if [[ ${_path##*/} == busybox ]]; then
+            _busybox_path="/${_path#/}"
+        else
+            _progs+=("/${_path#/}")
+        fi
     done
 
-    for _i in "${_progs[@]}"; do
-        _path=$(find_binary "$_i")
-        [ -z "$_path" ] && continue
-
+    inst "$_busybox" "$_busybox_path"
+    for _path in "${_progs[@]}"; do
         # do not remove existing destination files
-        [ -e "${_dstdir}/$_path" ] && continue
+        [ -e "${_dstdir}$_path" ] && continue
 
-        ln_r /usr/bin/busybox "$_path"
+        ln_r "$_busybox_path" "$_path"
     done
 }


### PR DESCRIPTION
`busybox --list` only lists the names of the included applets but does not show their paths. The busybox module looks for the path on the host system. It will skip the applet in case the binary is not found on the host system.

Rely on `busybox --list-all` to provide the path for the applets. That way all applets can be installed. Support getting relative paths (like `bin/busybox`) in addition to absolute paths (like `/bin/busybox`).

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
