### PR TITLE
fix(initqueue): enable dracut-initqueue.service using systemctl

### DIFF
--- a/modules.d/77initqueue/dracut-initqueue.service
+++ b/modules.d/77initqueue/dracut-initqueue.service
@@ -26,3 +26,6 @@ RemainAfterExit=yes
 # Bash ignores SIGTERM, so we send SIGHUP instead, to ensure that bash
 # terminates cleanly.
 KillSignal=SIGHUP
+
+[Install]
+WantedBy=initrd.target

--- a/modules.d/77initqueue/module-setup.sh
+++ b/modules.d/77initqueue/module-setup.sh
@@ -14,8 +14,6 @@ install() {
     if dracut_module_included "systemd"; then
         inst_script "$moddir/dracut-initqueue.sh" /usr/bin/dracut-initqueue
         inst_simple "$moddir/dracut-initqueue.service" "$systemdsystemunitdir/dracut-initqueue.service"
-        inst_simple "$systemdsystemunitdir"/initrd.target.wants/dracut-initqueue.service
-
         # Enable systemd type unit(s)
         $SYSTEMCTL -q --root "$initdir" enable dracut-initqueue.service
     fi


### PR DESCRIPTION
dracut-initqueue.service was missing a "WantedBy" setting, which made the `$SYSTEMCTL enable` call fail, hidden by the `-q`. At the same time, the `inst_simple` call for the symlink in `$systemdsystemunitdir` would fail if running dracut for a sysroot in which dracut isn't installed.

Add the missing "WantedBy" to the unit file and remove the unnecessary `inst_simple`. The only difference for the initramfs is that the symlink will be in `/etc/systemd/system/initrd.target.wants` instead of `/usr/lib/systemd/system/initrd.target.wants`. This matches what other modules do.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
