### PR TITLE
fix(i18n): support find applet from busybox in module-setup.sh

### DIFF
--- a/modules.d/20i18n/module-setup.sh
+++ b/modules.d/20i18n/module-setup.sh
@@ -39,7 +39,7 @@ install() {
             MAPNAME=${1%.map*}
 
             mapfile -t -d '' MAPS < <(
-                find "${dracutsysrootdir-}${kbddir}"/keymaps/ -type f,l \( -name "${MAPNAME}" -o -name "${MAPNAME}.map*" \) -print0
+                find "${dracutsysrootdir-}${kbddir}"/keymaps/ \( -type f -o -type l \) \( -name "${MAPNAME}" -o -name "${MAPNAME}.map*" \) -print0
             )
         fi
 
@@ -159,7 +159,7 @@ install() {
 
         # remove unnecessary files
         rm -f -- "${initdir}${kbddir}/consoletrans/utflist"
-        find "${initdir}${kbddir}/" -name README\* -delete
+        find "${initdir}${kbddir}/" -name README\* -exec rm -f {} +
         find "${initdir}${kbddir}/" -name '*.gz' -print -quit \
             | while read -r _line || [ -n "$_line" ]; do
                 inst_multiple gzip


### PR DESCRIPTION
busybox's `find` applet neither supports `-delete` nor specifying multiple types to `-type`. So replace `-delete` by a `rm` call and split the `-type` option.

Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
