### PR TITLE
perf: replace "sort | uniq" by "sort -u"

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -101,7 +101,7 @@ find_binary() {
 }
 
 ldconfig_paths() {
-    $DRACUT_LDCONFIG ${dracutsysrootdir:+-r ${dracutsysrootdir} -f /etc/ld.so.conf} -pN 2> /dev/null | grep -E -v '/(lib|lib64|usr/lib|usr/lib64)/[^/]*$' | sed -n 's,.* => \(.*\)/.*,\1,p' | sort | uniq
+    $DRACUT_LDCONFIG ${dracutsysrootdir:+-r ${dracutsysrootdir} -f /etc/ld.so.conf} -pN 2> /dev/null | grep -E -v '/(lib|lib64|usr/lib|usr/lib64)/[^/]*$' | sed -n 's,.* => \(.*\)/.*,\1,p' | sort -u
 }
 
 # Version comparison function.  Assumes Linux style version scheme.

--- a/modules.d/74fcoe/module-setup.sh
+++ b/modules.d/74fcoe/module-setup.sh
@@ -92,7 +92,7 @@ cmdline() {
             echo "ifname=${ifname}:${mac}"
             echo "fcoe=${ifname}:${dcb}:${mode}"
         done
-    } | sort | uniq
+    } | sort -u
 }
 
 # called by dracut

--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -123,7 +123,7 @@ install_iscsiroot() {
                 iscsi_address="[$iscsi_address]"
                 ;;
         esac
-        # Must be two separate lines, so that "sort | uniq" commands later
+        # Must be two separate lines, so that "sort -u" commands later
         # can sort out rd.iscsi.initiator= duplicates
         echo "rd.iscsi.initiator=$(normalized_iscsi_name "${iscsi_initiator}")"
         echo "netroot=iscsi:${iscsi_address}::${iscsi_port}:${iscsi_lun}:$(normalized_iscsi_name "${iscsi_targetname}")"
@@ -181,7 +181,7 @@ cmdline() {
         else
             install_softiscsi
         fi
-    } | sort | uniq
+    } | sort -u
 }
 
 # called by dracut

--- a/modules.d/74lunmask/module-setup.sh
+++ b/modules.d/74lunmask/module-setup.sh
@@ -40,7 +40,7 @@ cmdline() {
     }
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves_all get_lunmask
-    } | sort | uniq
+    } | sort -u
 }
 
 # called by dracut

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -131,8 +131,8 @@ test_setup() {
     if command -v mkosi-initrd &> /dev/null; then
         mkosi-initrd --kernel-version "$KVERSION" -t directory -o mkosi -O "$TESTDIR"
 
-        find "$TESTDIR"/mkosi/usr/lib/systemd/system/initrd.target.wants/ -printf "%f\n" | sort | uniq > systemd-mkosi
-        find "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/initrd.target.wants/ -printf "%f\n" | sort | uniq > systemd-dracut
+        find "$TESTDIR"/mkosi/usr/lib/systemd/system/initrd.target.wants/ -printf "%f\n" | sort -u > systemd-mkosi
+        find "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/initrd.target.wants/ -printf "%f\n" | sort -u > systemd-dracut
 
         # fail the test if mkosi installs some services that dracut does not
         mkosi_units=$(comm -23 systemd-mkosi systemd-dracut)
@@ -146,8 +146,8 @@ test_setup() {
     if command -v mkinitcpio &> /dev/null; then
         mkinitcpio -k "$KVERSION" --builddir "$TESTDIR" --save -A systemd
 
-        find "$TESTDIR"/mkinitcpio.*/root/usr/lib/systemd/system/ -printf "%f\n" | sort | uniq > systemd-mkinitcpio
-        find "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/ -printf "%f\n" | sort | uniq > systemd-dracut
+        find "$TESTDIR"/mkinitcpio.*/root/usr/lib/systemd/system/ -printf "%f\n" | sort -u > systemd-mkinitcpio
+        find "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/ -printf "%f\n" | sort -u > systemd-dracut
 
         # fail the test if mkinitcpio installs some services that dracut does not
         mkinitcpio_units=$(comm -23 systemd-mkinitcpio systemd-dracut)


### PR DESCRIPTION
Avoid spawning `uniq` by calling `sort` with `-u`. This parameter is also supported by BusyBox.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
