### PR TITLE
fix(convertfs): support find applet from busybox

### DIFF
--- a/modules.d/30convertfs/convertfs.sh
+++ b/modules.d/30convertfs/convertfs.sh
@@ -109,7 +109,7 @@ for dir in bin sbin lib lib64; do
     cp -axT ${CP_HARDLINK:+"$CP_HARDLINK"} --backup --suffix=.usrmove~ "$ROOT/$dir" "$ROOT/usr/${dir}.usrmove-new"
     echo "Clean up duplicates in \`$ROOT/usr/$dir'."
     # delete all symlinks that have been backed up
-    find "$ROOT/usr/${dir}.usrmove-new" -type l -name '*.usrmove~' -delete || :
+    find "$ROOT/usr/${dir}.usrmove-new" -type l -name '*.usrmove~' -exec rm -f {} + || :
     # replace symlink with backed up binary
     # shellcheck disable=SC2156
     find "$ROOT/usr/${dir}.usrmove-new" \


### PR DESCRIPTION
busybox's `find` applet does not support `-delete`. So replace `-delete` by a `rm` call.

Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
