### PR TITLE
fix(lsinitrd): use "find -exec ls" instead of "find -ls"

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -339,7 +339,7 @@ list_squash_content() {
         */erofs-root.img)
             (
                 cd "$SQUASH_EXTRACT" || return 1
-                find erofs-root/ -ls
+                find erofs-root/ -exec ls -ld {} +
             )
             ;;
     esac


### PR DESCRIPTION
busybox's `find` applet does not support `-ls`. Also the output of `find -ls` differs from the style of `ls` and `cpio`:

```
$ touch example foobar
$ find . -ls
  1127667      0 drwxrwxr-x   2 root     root           80 Aug 25 17:59 .
  1127669      0 -rw-rw-r--   1 root     root            0 Aug 25 17:59 ./foobar
  1127668      0 -rw-rw-r--   1 root     root            0 Aug 25 17:59 ./example
$ find . -exec ls -ld {} +
drwxrwxr-x 2 root root 80 Aug 25 17:59 .
-rw-rw-r-- 1 root root  0 Aug 25 17:59 ./example
-rw-rw-r-- 1 root root  0 Aug 25 17:59 ./foobar
```

So replace `-ls` by a `ls` call.

Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
