### PR TITLE
fix(dracut-functions): support head applet from busybox

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -55,7 +55,7 @@ trim() {
 # is_elf <path>
 # Returns success if the given path is an ELF. Only checks the first 4 bytes.
 is_elf() {
-    [[ $(head --bytes=4 "$1") == $'\x7fELF' ]]
+    [[ $(head -c 4 "$1") == $'\x7fELF' ]]
 }
 
 # find a binary.  If we were not passed the full path directly,


### PR DESCRIPTION
busybox's `head` applet does not support the long form `--bytes` but it supports the short form `-c`.

Part of: https://github.com/dracut-ng/dracut/issues/2437

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
