### PR TITLE
test: mark tests using a HTTP server requiring python3

### DIFF
--- a/test/TEST-45-SYSTEMD-IMPORT/test.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/test.sh
@@ -11,7 +11,8 @@ TEST_DESCRIPTION="download and import disk images at boot with systemd-import"
 IMPORT_VERIFY="checksum"
 
 test_check() {
-    require_binaries_for_test /usr/lib/systemd/systemd-importd systemd-dissect tar zstd
+    # python3 needed for HTTP server
+    require_binaries_for_test python3 /usr/lib/systemd/systemd-importd systemd-dissect tar zstd
 }
 
 client_run() {

--- a/test/TEST-61-CHRONY/test.sh
+++ b/test/TEST-61-CHRONY/test.sh
@@ -14,7 +14,8 @@ FAKE_TIME="2100-01-01T00:00:00"
 SSL_CERT="webserver.pem"
 
 test_check() {
-    require_binaries_for_test chronyd openssl systemctl
+    # python3 needed for HTTP server
+    require_binaries_for_test chronyd openssl python3 systemctl
 }
 
 client_run() {


### PR DESCRIPTION
The `start_webserver` function calls `python3`. So mark those test requiring `python3`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
