### PR TITLE
fix(chrony): support _chrony username

### DIFF
--- a/modules.d/74chrony/parse-ntp.sh
+++ b/modules.d/74chrony/parse-ntp.sh
@@ -45,7 +45,7 @@ parse_ntp_source() {
 }
 
 mkdir -p -m 0750 /run/chrony
-chown chrony: /run/chrony
+chown "$(get_user _chrony chrony):" /run/chrony
 mkdir /run/chrony/dracut.sources.d
 
 for _i in $(getargs rd.ntp); do

--- a/modules.d/74nfs/nfs-lib.sh
+++ b/modules.d/74nfs/nfs-lib.sh
@@ -155,16 +155,3 @@ mount_nfs() {
     fi
     mount -t "$nfs" -o"$options" "$server:$path" "$mntdir"
 }
-
-get_rpc_user() {
-    while read -r line; do
-        user="${line%%:*}"
-        case $user in
-            _rpc | rpc | rpcuser | nfsnobody)
-                echo "$user"
-                return
-                ;;
-        esac
-    done < /etc/passwd
-    echo "root"
-}

--- a/modules.d/74nfs/nfs-start-rpc.sh
+++ b/modules.d/74nfs/nfs-start-rpc.sh
@@ -20,7 +20,7 @@ str_starts "$nfs" "nfs" || return 0
 command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
 if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
     mkdir -p /run/rpcbind
-    chown "$(get_rpc_user):" /run/rpcbind
+    chown "$(get_user _rpc rpc rpcuser nfsnobody):" /run/rpcbind
     rpcbind
 fi
 

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -465,6 +465,23 @@ check_quiet() {
     fi
 }
 
+# get_user <user1> [user2 ...]
+# Look up /etc/passwd for the first matching username among candidates.
+# Output the username if found, or 'root' as a fallback.
+get_user() {
+    local line user
+    while read -r line; do
+        user="${line%%:*}"
+        case " $* " in
+            *" $user "*)
+                echo "$user"
+                return 0
+                ;;
+        esac
+    done < /etc/passwd
+    echo "root"
+}
+
 incol2() {
     debug_off
     local check


### PR DESCRIPTION
The test 61 chrony fails on Debian/Ubuntu and this failure can be seen
in the logs:

```
dracut-cmdline[278]: chown: invalid user: 'chrony:'
[...]
chronyd[461]: Wrong owner of /run/chrony (UID != 988)
```

The username used on Debian/Ubuntu is `_chrony`.

This fix is not enough to make test 61 chrony work. chrony-wait.service is still running into a timeout.

Partially fixes: https://github.com/dracut-ng/dracut/issues/2541

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
