### PR TITLE
fix(shutdown): make "timeout" call busybox-compatible

### DIFF
--- a/modules.d/86shutdown/shutdown.sh
+++ b/modules.d/86shutdown/shutdown.sh
@@ -74,7 +74,7 @@ umount_a() {
         # be produced by the shell.
         (
             set +m
-            timeout --signal=KILL "$_umount_timeout" umount "$mp"
+            timeout -s KILL "$_umount_timeout" umount "$mp"
         ) 2>&7
         local ret=$?
         if [ $ret -eq 0 ]; then


### PR DESCRIPTION
Busybox' `timeout` does not support long-form `--signal`. Use short `-s` instead.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
