### PR TITLE
fix(cli): detect same-filesystem btrfs subvolumes for fsfreeze safety check

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3661,22 +3661,17 @@ if [[ $outfile_final ]]; then
     fi
 fi
 
-btrfs_uuid() {
-    btrfs filesystem show "$1" | sed -n '1s/^.*uuid: //p'
-}
-
 freeze_ok_for_btrfs() {
-    local mnt uuid1 uuid2
+    local dest_uuid root_uuid
     # If the output file is on btrfs, we need to make sure that it's
     # not on a subvolume of the same file system as the root FS.
     # Otherwise, fsfreeze() might freeze the entire system.
     # This is most conveniently checked by comparing the FS uuid.
 
     [[ "$(stat -f -c %T -- "/")" == "btrfs" ]] || return 0
-    mnt=$(stat -c %m -- "$1")
-    uuid1=$(btrfs_uuid "$mnt")
-    uuid2=$(btrfs_uuid "/")
-    [[ $uuid1 && $uuid2 && $uuid1 != "$uuid2" ]]
+    dest_uuid=$(findmnt -no uuid -T "$1")
+    root_uuid=$(findmnt -no uuid -T "/")
+    [[ $dest_uuid && $root_uuid && $dest_uuid != "$root_uuid" ]]
 }
 
 freeze_ok_for_fstype() {


### PR DESCRIPTION
## What
Fix `freeze_ok_for_btrfs()` in `dracut.sh` failing to detect same-filesystem btrfs subvolumes when the subvolume is mounted at its own mountpoint.

## Why
When generating an initramfs, dracut calls `freeze_ok_for_btrfs()` before fsfreezing the output file's mountpoint. Before this fix, `btrfs filesystem show <path>` failed with `ERROR: not a valid btrfs filesystem: <path>` when `<path>` was a subvolume mounted at its own mountpoint (e.g. `/var/tmp` on a dedicated subvolume), even though it was on the same filesystem as `/`. This broke the UUID comparison that `freeze_ok_for_btrfs()` uses to decide whether `fsfreeze` is safe, so instead of comparing UUIDs it just logged noise and skipped the fsfreeze write-barrier.

Reproduced:

    $ btrfs filesystem show /var/tmp
    ERROR: not a valid btrfs filesystem: /var/tmp

    $ findmnt -no uuid -T /
    4789e87e-afe3-47fe-aa80-3918f97b55c9
    $ findmnt -no uuid -T /var/tmp
    4789e87e-afe3-47fe-aa80-3918f97b55c9

`findmnt` resolves the UUID correctly for both.
### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
