### PR TITLE
ci(debian): install systemd-tpm package on ubuntu:devel

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -22,7 +22,7 @@ RUN case $(dpkg --print-architecture) in \
         arm64) arch_pkgs="qemu-efi-aarch64 qemu-system-arm" ;; \
     esac; \
     if [ "$DISTRIBUTION" != "debian:latest" ]; then cpio=3cpio; else cpio=cpio; fi; \
-    if [ "$DISTRIBUTION" = "debian:sid" ]; then \
+    if [ "$DISTRIBUTION" != "debian:latest" ] && [ "$DISTRIBUTION" != "ubuntu:rolling" ]; then \
         systemd_pkgs="systemd-tpm"; \
     fi; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \


### PR DESCRIPTION
systemd 261-2 has split out systemd-pcrextend into systemd-tpm package (see https://packages.debian.org/sid/systemd-tpm).

So also install `systemd-tpm` on Ubuntu 26.10 aka `ubuntu:devel`.

Follow-up on c4a53b38e2d7fd9d3898675d12d0d97221487752 \
Fixes: https://github.com/dracut-ng/dracut/issues/2668

**Note**: Changes needed for `debian:sid` will normally trickle down to `ubuntu:devel`.


### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
