### PR TITLE
support mktemp applet from busybox

### DIFF
--- a/modules.d/74znet/module-setup.sh
+++ b/modules.d/74znet/module-setup.sh
@@ -26,7 +26,7 @@ install() {
     inst_multiple grep sed seq readlink chzdev
     if [[ $hostonly ]]; then
         local _tempfile
-        _tempfile=$(mktemp --tmpdir="${DRACUT_TMPDIR}" dracut-zdev.XXXXXX)
+        _tempfile=$(mktemp -p "${DRACUT_TMPDIR}" dracut-zdev.XXXXXX)
         {
             chzdev qeth --export - --configured --persistent --quiet --type
             chzdev lcs --export - --configured --persistent --quiet --type

--- a/test/TEST-80-GETARG/test.sh
+++ b/test/TEST-80-GETARG/test.sh
@@ -88,7 +88,7 @@ test_run() {
 
         export PATH=".:$PATH"
         # shellcheck disable=SC2034  # NEWROOT defined for dracut-lib.sh, set by base/init.sh
-        NEWROOT=$(mktemp --directory -p "$TESTDIR" newroot.XXXXXXXXXX)
+        NEWROOT=$(mktemp -d -p "$TESTDIR" newroot.XXXXXXXXXX)
         # shellcheck disable=SC2034  # PREFIX defined for dracut-lib.sh to avoid creating /run/initramfs
         PREFIX=/nonexistent
 

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -65,7 +65,7 @@ test_run() {
 }
 
 test_setup() {
-    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX)
+    CPIO_TESTDIR=$(mktemp -d -p "$TESTDIR" cpio-test.XXXXXXXXXX)
     export CPIO_TESTDIR
     return 0
 }


### PR DESCRIPTION
busybox's `mktemp` applet does not support the long form `--tmpdir` but it supports the short form `-p`. busybox's `mktemp` applet does not support the long form `--directory` but it supports the short form `-d`.

Part of: https://github.com/dracut-ng/dracut/issues/2437
### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
