### PR TITLE
fix(dracut-systemd): mark dracut-shutdown.service as WantedBy=sysinit.target

### DIFF
--- a/modules.d/77dracut-systemd/dracut-shutdown.service
+++ b/modules.d/77dracut-systemd/dracut-shutdown.service
@@ -12,3 +12,6 @@ OnFailure=dracut-shutdown-onfailure.service
 RemainAfterExit=yes
 Type=oneshot
 ExecStop=/usr/lib/dracut/dracut-initramfs-restore
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
The "install" target in Makefile manually creates the symlink in `$(systemdsystemunitdir)/sysinit.target.wants`, marking the dependency in the service file lets systemd tools understand it. This is particularly needed when cross-building an initramfs where dracut isn't installed in the sysroot, but `dracut-shutdown.service` needs to be.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
