### PR TITLE
feat(rt): make dracut-initramfs-restore.sh POSIX compatible

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -13,17 +13,17 @@ trap 'echo "Received SIGTERM signal, ignoring!" >&2' TERM
 
 KERNEL_VERSION="$(uname -r)"
 
-[[ $dracutbasedir ]] || dracutbasedir=/usr/lib/dracut
+[ "$dracutbasedir" ] || dracutbasedir=/usr/lib/dracut
 
 find_initrd_for_kernel_version() {
     local kernel_version="$1"
-    local base_path files initrd machine_id
+    local base_path f initrd machine_id
 
-    if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
+    if [ -d /efi/Default ] || [ -d /boot/Default ] || [ -d /boot/efi/Default ]; then
         machine_id="Default"
-    elif [[ -s /etc/machine-id ]]; then
+    elif [ -s /etc/machine-id ]; then
         read -r machine_id < /etc/machine-id
-        [[ $machine_id == "uninitialized" ]] && machine_id="Default"
+        [ "$machine_id" = "uninitialized" ] && machine_id="Default"
     else
         machine_id="Default"
     fi
@@ -38,15 +38,17 @@ find_initrd_for_kernel_version() {
         done
     fi
 
-    if [[ -f /lib/modules/${kernel_version}/initrd ]]; then
+    if [ -f "/lib/modules/${kernel_version}/initrd" ]; then
         echo "/lib/modules/${kernel_version}/initrd"
-    elif [[ -f /boot/initramfs-${kernel_version}.img ]]; then
+    elif [ -f "/boot/initramfs-${kernel_version}.img" ]; then
         echo "/boot/initramfs-${kernel_version}.img"
     else
-        files=(/boot/initr*"${kernel_version}"*)
-        if [ "${#files[@]}" -ge 1 ] && [ -e "${files[0]}" ]; then
-            echo "${files[0]}"
-        fi
+        for f in /boot/initr*"${kernel_version}"*; do
+            if [ -e "${f}" ]; then
+                echo "${f}"
+                return
+            fi
+        done
     fi
 }
 
@@ -59,15 +61,15 @@ extract_initrd() {
     fi
 }
 
-mount -o ro /boot &> /dev/null || :
+mount -o ro /boot > /dev/null 2>&1 || :
 
 IMG=$(find_initrd_for_kernel_version "$KERNEL_VERSION")
 if [ -z "$IMG" ]; then
-    if [[ -f /boot/initramfs-linux.img ]]; then
+    if [ -f /boot/initramfs-linux.img ]; then
         IMG="/boot/initramfs-linux.img"
-    elif [[ -f /boot/initrd.img ]]; then
+    elif [ -f /boot/initrd.img ]; then
         IMG="/boot/initrd.img"
-    elif [[ -f /initrd.img ]]; then
+    elif [ -f /initrd.img ]; then
         IMG="/initrd.img"
     else
         echo "No initramfs image found to restore!"
@@ -85,13 +87,13 @@ if ! extract_initrd "$IMG"; then
 fi
 rm -f -- .need_shutdown
 
-if [[ -f squashfs-root.img ]]; then
+if [ -f squashfs-root.img ]; then
     if ! unsquashfs -no-xattrs -f -d . squashfs-root.img > /dev/null; then
         echo "Squash module is enabled for this initramfs but failed to unpack squash-root.img" >&2
         rm -f -- /run/initramfs/shutdown
         exit 1
     fi
-elif [[ -f erofs-root.img ]]; then
+elif [ -f erofs-root.img ]; then
     if ! fsck.erofs --extract=. --overwrite erofs-root.img > /dev/null; then
         echo "Squash module is enabled for this initramfs but failed to unpack erofs-root.img" >&2
         rm -f -- /run/initramfs/shutdown
@@ -102,7 +104,7 @@ fi
 if grep -qs -w selinux /sys/kernel/security/lsm \
     && [ -e /etc/selinux/config ] && [ -x /usr/sbin/setfiles ]; then
     . /etc/selinux/config
-    if [[ $SELINUX != "disabled" && -n $SELINUXTYPE ]]; then
+    if [ "$SELINUX" != "disabled" ] && [ -n "$SELINUXTYPE" ]; then
         /usr/sbin/setfiles -v -r /run/initramfs /etc/selinux/"${SELINUXTYPE}"/contexts/files/file_contexts /run/initramfs > /dev/null
     fi
 fi


### PR DESCRIPTION
Most changes replace bash's `[[` with `[` and quote parameters where needed. Also avoid `&>` redirect shorthand.

The one more complex change is in `find_initrd_for_kernel_version()`, where "create array from glob, use element 0 if existing path" is replaced with "iterate over glob, use element if existing path" to do the same thing: unless the glob doesn't match anything, the first element will exist and be used.

This makes `dracut-initramfs-restore.sh` work on systems without bash (e.g. busybox shell).

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
