### PR TITLE
fix(base): support readlink applet from busybox

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -512,9 +512,18 @@ udevproperty() {
     done
 }
 
+_resolve_path() {
+    # busybox readlink does not support the option -e. So rely on the realpath applet.
+    if command -v realpath > /dev/null; then
+        realpath "$@"
+    else
+        readlink -e -q "$@"
+    fi
+}
+
 find_mount() {
     local dev wanted_dev
-    wanted_dev="$(readlink -e -q "$1")"
+    wanted_dev="$(_resolve_path "$1")"
     while read -r dev _ || [ -n "$dev" ]; do
         [ "$dev" = "$wanted_dev" ] && echo "$dev" && return 0
     done < /proc/mounts
@@ -645,7 +654,7 @@ copytree() {
     local src="$1" dest="$2"
     [ -d "$src" ] || return 1
     mkdir -p "$dest" || return 1
-    dest=$(readlink -e -q "$dest") || return 1
+    dest=$(_resolve_path "$dest") || return 1
     (
         cd "$src" || exit 1
         cp -af . -t "$dest"
@@ -699,8 +708,9 @@ devnames() {
     [ -n "$dev" ] || return 255
 
     for d in $dev; do
+        [ -e "$d" ] || return 255
         names="$names
-$(readlink -e -q "$d")" || return 255
+$(_resolve_path "$d")"
     done
 
     echo "${names#


### PR DESCRIPTION
busybox's `readlink` applet does not support the option `-e` option.

These `readlink` calls can be replaced by `realpath`, but `realpath` is not included in the initrd. So support using `readlink` (when busybox is used) and fall back to keep using `readlink` otherwise. Since `realpath` will return successfully on non-existing path, check the path exists if needed.

Fixes: https://github.com/dracut-ng/dracut/issues/2731
Part of: https://github.com/dracut-ng/dracut/issues/2437

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
