### PR TITLE
fix(busybox): do not rely on CONFIG_FEATURE_INSTALLER=y

### DIFF
--- a/modules.d/81busybox/module-setup.sh
+++ b/modules.d/81busybox/module-setup.sh
@@ -21,7 +21,7 @@ install() {
 
     # do not depend on CONFIG_FEATURE_INSTALLER
     # install busybox symlinks manually
-    for _path in $($_busybox --list-all); do
+    for _path in $($_busybox --list-full); do
         if [[ ${_path##*/} == busybox ]]; then
             _busybox_path="/${_path#/}"
         else

--- a/modules.d/81busybox/module-setup.sh
+++ b/modules.d/81busybox/module-setup.sh
@@ -13,15 +13,27 @@ check() {
 
 # called by dracut
 install() {
-    local _path _busybox _busybox_path
+    local _path _p _busybox _busybox_path
     local _dstdir="${dstdir:-"$initdir"}"
     local _progs=()
     _busybox=$(find_binary busybox)
     _busybox_path="/usr/bin/busybox"
 
-    # do not depend on CONFIG_FEATURE_INSTALLER
     # install busybox symlinks manually
     for _path in $($_busybox --list-full); do
+        # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
+        # has only plain names
+        if [[ ${_path##*/} == "${_path}" ]]; then
+            _p=$(find_binary "${_path}")
+            if [[ $_p ]]; then
+                # if the applet is installed, use its path
+                _path="${_p}"
+            else
+                # otherwise guess usr/bin/
+                _path="usr/bin/${_path}"
+            fi
+        fi
+
         if [[ ${_path##*/} == busybox ]]; then
             _busybox_path="/${_path#/}"
         else


### PR DESCRIPTION
`busybox --list-full` provides full paths [only if busybox was built with `CONFIG_FEATURE_INSTALLER=y`](https://github.com/vda-linux/busybox_mirror/blob/15666f3e9a0b54305cec1b01f34bc5b2a1794e74/libbb/appletlib.c#L857-L860), otherwise the result is only a list of applet names (like `--list`). Using those applet links will be placed in / in the initramfs, which is not on `PATH`, causing chaos.

If we get plain applet names, try to find their installed paths, and use those if found. Otherwise guess `usr/bin`. Of the distros used in CI this affects opensuse and void.

Use `--list-full` instead of `--list-all` because that is the documented option name. `--list-all` also works because the busybox code [only checks if there is a non-\0 character after --list](https://github.com/vda-linux/busybox_mirror/blob/15666f3e9a0b54305cec1b01f34bc5b2a1794e74/libbb/appletlib.c#L858).

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
