### PR TITLE
fix(busybox): do not install blkid applet

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -34,6 +34,11 @@ install() {
 
     # install busybox symlinks manually
     for _path in ${_busybox_applets}; do
+        # blkid is not compatible: https://github.com/dracut-ng/dracut/issues/2512
+        if [[ ${_path##*/} == blkid ]]; then
+            continue
+        fi
+
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names
         if [[ ${_path##*/} == "${_path}" ]]; then


### PR DESCRIPTION
The busybox `blkid` applet is not compatible with Dracut for LVM. Test 20 and 26 are failing with the `alpine:busybox-edge` container.

So do not install the `blkid` applet until this bug is fixed.

See https://github.com/dracut-ng/dracut/issues/2512

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
