### PR TITLE
feat(shell-interpreter): default to busybox if available

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -39,6 +39,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/33
             continue
         fi
+        if [[ ${_path##*/} == losetup ]]; then
+            # The busybox losetup applet does not support the option --show.
+            # See https://github.com/vda-linux/busybox_mirror/issues/37
+            continue
+        fi
         if [[ ${_path##*/} == mke2fs ]]; then
             # e2fsprogs provides mke2fs. mkfs.ext2, mkfs.ext3, and mkfs.ext4 are symlinks to it.
             # Busybox does not provide a mkfs.ext4 applet and mkfs.ext* would point to busybox then.

--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -54,6 +54,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/35
             continue
         fi
+        if [[ ${_path##*/} == sulogin ]]; then
+            # The busybox sulogin applet does not support the option -e.
+            # See https://github.com/vda-linux/busybox_mirror/issues/36
+            continue
+        fi
 
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names

--- a/modules.d/68lvmmerge/lvmmerge.sh
+++ b/modules.d/68lvmmerge/lvmmerge.sh
@@ -8,7 +8,17 @@ do_merge() {
 
     systemctl --no-block stop sysroot.mount
     swapoff -a
-    umount -R /sysroot
+
+    # busybox does not support umount --recursive
+    local target
+    sed '1!G;h;$!d' /proc/self/mountinfo | while read -r _ _ _ _ target _; do
+        case "$target" in
+            /sysroot | /sysroot/*)
+                target=$(printf '%b' "$target")
+                umount "$target"
+                ;;
+        esac
+    done
 
     for tag in $(getargs rd.lvm.mergetags); do
         lvm vgs --noheadings -o vg_name \

--- a/modules.d/70dmsquash-live/apply-live-updates.sh
+++ b/modules.d/70dmsquash-live/apply-live-updates.sh
@@ -17,6 +17,6 @@ fi
 # release resources on iso-scan boots with rd.live.ram
 if [ -d /run/initramfs/isoscan ] \
     && [ -f /run/initramfs/squashed.img ] || [ -f /run/initramfs/rootfs.img ]; then
-    umount --detach-loop /run/initramfs/live
+    umount -d /run/initramfs/live
     umount /run/initramfs/isoscan
 fi

--- a/modules.d/77selinux/selinux-loadpolicy.sh
+++ b/modules.d/77selinux/selinux-loadpolicy.sh
@@ -46,7 +46,18 @@ rd_load_policy() {
             [ -e "$NEWROOT"/.autorelabel ] && LANG=C /usr/sbin/setenforce 0
             mount --rbind /dev "$NEWROOT/dev"
             LANG=C chroot "$NEWROOT" /sbin/restorecon -R /dev
-            umount -R "$NEWROOT/dev"
+
+            # busybox does not support umount --recursive
+            local target
+            sed '1!G;h;$!d' /proc/self/mountinfo | while read -r _ _ _ _ target _; do
+                case "$target" in
+                    "$NEWROOT"/dev | "$NEWROOT"/dev/*)
+                        target=$(printf '%b' "$target")
+                        umount "$target"
+                        ;;
+                esac
+            done
+
             return 0
         fi
 

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -512,9 +512,17 @@ udevproperty() {
     done
 }
 
+_resolve_path() {
+    if command -v realpath > /dev/null; then
+        realpath "$@"
+    else
+        readlink -e -q "$@"
+    fi
+}
+
 find_mount() {
     local dev wanted_dev
-    wanted_dev="$(readlink -e -q "$1")"
+    wanted_dev="$(_resolve_path "$1")"
     while read -r dev _ || [ -n "$dev" ]; do
         [ "$dev" = "$wanted_dev" ] && echo "$dev" && return 0
     done < /proc/mounts
@@ -645,7 +653,7 @@ copytree() {
     local src="$1" dest="$2"
     [ -d "$src" ] || return 1
     mkdir -p "$dest" || return 1
-    dest=$(readlink -e -q "$dest") || return 1
+    dest=$(resolve_path "$dest") || return 1
     (
         cd "$src" || exit 1
         cp -af . -t "$dest"
@@ -727,8 +735,9 @@ devnames() {
     esac
 
     for d in $dev; do
+        [ -e "$d" ] || return 255
         names="$names
-$(readlink -e -q "$d")" || return 255
+$(_resolve_path "$d")"
     done
 
     echo "${names#

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -97,14 +97,6 @@ install() {
     inst_simple "$moddir/insmodpost.sh" /sbin/insmodpost.sh
 
     if ! dracut_module_included "systemd"; then
-        # Prefer the host's util-linux switch_root over the busybox
-        # applet. When the busybox dracut module is included it runs first and
-        # may have symlinked switch_root to its applet. Drop that symlink so
-        # the host binary is installed instead
-        if dracut_module_included "busybox"; then
-            rm -f "${initdir}/bin/switch_root" "${initdir}/sbin/switch_root" \
-                "${initdir}/usr/bin/switch_root" "${initdir}/usr/sbin/switch_root"
-        fi
         inst_multiple switch_root || dfatal "Failed to install switch_root"
         inst_script "$moddir/init.sh" "/init"
         inst_hook cmdline 01 "$moddir/parse-kernel.sh"

--- a/modules.d/85shell-interpreter/module-setup.sh
+++ b/modules.d/85shell-interpreter/module-setup.sh
@@ -17,8 +17,13 @@ depends() {
         fi
     done
 
-    shell=$(realpath /bin/sh)
-    shell=${shell##*/}
+    local shell
+    if check_module "busybox"; then
+        shell=busybox
+    else
+        shell=$(realpath /bin/sh)
+        shell=${shell##*/}
+    fi
 
     echo "$shell"
     return 0

--- a/modules.d/85shell-interpreter/module-setup.sh
+++ b/modules.d/85shell-interpreter/module-setup.sh
@@ -8,7 +8,7 @@
 
 depends() {
     # priority order
-    shells='bash dash busybox'
+    shells='bash busybox dash'
 
     for shell in $shells; do
         if dracut_module_included "$shell"; then

--- a/test/TEST-15-BUSYBOX/test.sh
+++ b/test/TEST-15-BUSYBOX/test.sh
@@ -61,13 +61,6 @@ test_run() {
     # Each must resolve to busybox in the resulting initrd.
     check_applets_from_busybox "$TESTDIR/initramfs.testing" ash cp ip ls mv mkdir sleep tr || ret=1
 
-    # switch_root must NOT be a busybox symlink as the base module reinstalls
-    # the host util-linux version on top of any symlink the busybox module left
-    if lsinitrd "$TESTDIR/initramfs.testing" | grep -E '^l.* switch_root -> .*busybox'; then
-        echo "FAIL: switch_root is a busybox symlink, host version was not preserved" >&2
-        ret=1
-    fi
-
     declare -a disk_args=()
     qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root


### PR DESCRIPTION
In case a specific shell interpreter like bash, dash, or busybox is requested by adding the module (e.g. `--add bash`) or pulled in as dependency, the shell-interpreter will pick that shell. Otherwise it will pick the shell `/bin/sh` points to. On Debian/Ubuntu this shell is dash.

Dash is very minimal and inconvenient in case of interactive usage. In case busybox is available prefer to include busybox instead.

In case you do not like this approach, we could make it configurable which order to use when looking for the shell.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/2150657

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
