### PR TITLE
feat(drm): limit DRM module installation to amdgpu, loongson, and radeon

### DIFF
--- a/modules.d/45drm/module-setup.sh
+++ b/modules.d/45drm/module-setup.sh
@@ -19,7 +19,11 @@ installkernel() {
             "=drivers/video/backlight"
     fi
 
-    hostonly=$(optional_hostonly) instmods amdkfd hyperv_fb "=drivers/pwm"
+    if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
+        hostonly=$(optional_hostonly) instmods amdkfd hyperv_fb "=drivers/pwm"
+    else
+        hostonly=$(optional_hostonly) instmods "=drivers/pwm"
+    fi
 
     # if the hardware is present, include module even if it is not currently loaded,
     # as we could e.g. be in the installer; nokmsboot boot parameter will disable
@@ -51,9 +55,18 @@ installkernel() {
             hostonly=$(optional_hostonly) instmods "$modname"
         done
     else
-        dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm" "=drivers/staging"
-        # also include privacy screen providers (see above comment)
-        # atm all providers live under drivers/platform/x86
-        dracut_instmods -o -s "drm_privacy_screen_register" "=drivers/platform/x86"
+        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
+            dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm" "=drivers/staging"
+            # also include privacy screen providers (see above comment)
+            # atm all providers live under drivers/platform/x86
+            dracut_instmods -o -s "drm_privacy_screen_register" "=drivers/platform/x86"
+        else
+            # If we are using mips64 (assumed to be MIPS-based
+            # Loongson), only install loongson, radeon, and amdgpu as
+            # these are the only three DRM drivers supported by these
+            # platforms. We need to minimise the sizes of the initramfs so
+            # that it fits within the RAM allocated by the system firmware.
+            dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm/amd/amdgpu" "=drivers/gpu/drm/amd/amdxcp" "=drivers/gpu/drm/loongson" "=drivers/gpu/drm/radeon"
+        fi
     fi
 }


### PR DESCRIPTION
If we are using mips64el (assumed to be MIPS-based Loongson), only install modules for loongson, radeon, and amdgpu as these are the only three DRM drivers supported by these platforms. We need to minimise the sizes of the initramfs so that it fits within the RAM allocated by the system firmware.

Upstreamed from https://github.com/AOSC-Dev/aosc-os-abbs/blob/9173a17045c165d6c60944ed7a0f1c1deb606fa8/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
