### PR TITLE
fix(dm): install real blkid if udev rules need -o

### DIFF
--- a/modules.d/70dm/module-setup.sh
+++ b/modules.d/70dm/module-setup.sh
@@ -30,4 +30,11 @@ install() {
     inst_rules "$moddir/11-dm.rules"
 
     inst_hook shutdown 25 "$moddir/dm-shutdown.sh"
+
+    if dracut_module_included "busybox" && grep -q "blkid -o udev" "${initdir}${udevdir}/rules.d/13-dm-disk.rules" 2> /dev/null; then
+        # The busybox blkid applet does not support the option -o.
+        rm -f "${initdir}/bin/blkid" "${initdir}/sbin/blkid" \
+            "${initdir}/usr/bin/blkid" "${initdir}/usr/sbin/blkid"
+        inst_binary blkid
+    fi
 }


### PR DESCRIPTION
The busybox `blkid` applet does not support the option `-o`. The `13-dm-disk.rules` udev rule might either use the builtin blkid or call `/sbin/blkid -o udev -p $tempnode`. The latter is not supported by busybox.

So check the udev rule to call `blkid` with `-o` and replace the busybox applet in this case.

Fixes: https://github.com/dracut-ng/dracut/issues/2512

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
