### PR TITLE
fix(busybox): do not install blkid if udev rules need -o

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -34,6 +34,12 @@ install() {
 
     # install busybox symlinks manually
     for _path in ${_busybox_applets}; do
+        if [[ ${_path##*/} == blkid ]] && grep -qr "blkid -o" "${udevdir}/rules.d" 2> /dev/null; then
+            # The busybox blkid applet does not support the option -o.
+            # See https://github.com/vda-linux/busybox_mirror/issues/33
+            continue
+        fi
+
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names
         if [[ ${_path##*/} == "${_path}" ]]; then


### PR DESCRIPTION
The busybox `blkid` applet does not support the option `-o`. The `13-dm-disk.rules` udev rule might either use the builtin blkid or call `/sbin/blkid -o udev -p $tempnode`. The latter is not supported by busybox.

So check the udev rule to call `blkid` with `-o` and do not install this busybox applet in this case.

Fixes: https://github.com/dracut-ng/dracut/issues/2512

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
