### PR TITLE
fix(busybox): do not install mount applet

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -39,6 +39,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/33
             continue
         fi
+        if [[ ${_path##*/} == mount ]]; then
+            # The busybox mount applet does not resolve "auto" to the actual filesystem.
+            # See https://github.com/vda-linux/busybox_mirror/issues/34
+            continue
+        fi
 
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names


### PR DESCRIPTION
The busybox `mount` applet does not resolve "auto" to the actual filesystem and therefore passes `auto` directly to mount(2). If the target partition's filesystem driver (e.g., `ext4`, `xfs`) is compiled as a module and not yet loaded into `/proc/filesystems`, the kernel skips `request_module()` and returns `EINVAL` (Invalid argument). For example `test/test.sh debian:sid 10` fails with, because `ext4` is not loaded:

```
systemd[1]: Mounting sysroot.mount - /sysroot...
mount: mounting /dev/disk/by-label/dracut on /sysroot failed: Invalid argument
```

Instead of adding a quirky workaround to probe the device and load the relevant filesystem driver, do not install the `mount` applet.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
