### PR TITLE
Install dracut-cpio to bindir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ man8pages = man/dracut.8 \
             modules.d/77dracut-systemd/dracut-pre-udev.service.8 \
             modules.d/77initqueue/dracut-initqueue.service.8
 
+ifeq ($(enable_dracut_cpio),yes)
+man8pages += man/dracut-cpio.8
+endif
+
 manpages = $(man1pages) $(man5pages) $(man7pages) $(man8pages)
 
 .PHONY: install clean distclean archive test all check AUTHORS CONTRIBUTORS doc

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ endif
 		install -m 0755 dracut-util $(DESTDIR)$(pkglibdir)/dracut-util; \
 	fi
 ifeq ($(enable_dracut_cpio),yes)
-	install -m 0755 dracut-cpio $(DESTDIR)$(pkglibdir)/dracut-cpio
+	install -m 0755 dracut-cpio $(DESTDIR)$(bindir)/dracut-cpio
 endif
 	mkdir -p $(DESTDIR)${prefix}/lib/kernel/install.d
 	install -m 0755 install.d/50-dracut.install $(DESTDIR)${prefix}/lib/kernel/install.d/50-dracut.install

--- a/dracut.sh
+++ b/dracut.sh
@@ -2088,7 +2088,7 @@ if command -v 3cpio > /dev/null; then
 fi
 
 if [[ $enhanced_cpio == "yes" ]]; then
-    enhanced_cpio="$dracutbasedir/dracut-cpio"
+    enhanced_cpio="$(command -v dracut-cpio)"
     if [[ $threecpio_help_output == *--data-align* ]]; then
         # align based on statfs optimal transfer size
         cpio_align=$(stat -f -c "%s" -- "$initdir")

--- a/dracut.sh
+++ b/dracut.sh
@@ -175,9 +175,9 @@ Creates initial ramdisk images for preloading modules
   --tmpdir [DIR]        Temporary directory to be used instead of default
                          ${TMPDIR:-/var/tmp}.
   -r, --sysroot [DIR]   Specify sysroot directory to collect files from.
-  -l, --local           Local mode. Use modules from the current working
-                         directory instead of the system-wide installed in
-                         /usr/lib/dracut/modules.d.
+  -l, --local           Local mode. Use modules and executables from the
+                         current working directory instead of the system-wide
+                         install in /usr/lib/dracut/modules.d.
                          Useful when running dracut from a git checkout.
   -H, --hostonly        Host-only mode: Install only what is needed for
                          booting the local host instead of a generic host.
@@ -860,8 +860,12 @@ while :; do
                     ;;
                 -l | --local)
                     allowlocal="yes"
-                    [[ -f "$(readlink -f "${0%/*}")/dracut.sh" ]] \
-                        && dracutbasedir="$(readlink -f "${0%/*}")"
+                    if [[ -f "$(readlink -f "${0%/*}")/dracut.sh" ]]; then
+                        dracutbasedir="$(readlink -f "${0%/*}")"
+                        # dracutbasedir is repository, add to PATH to use built
+                        # executables
+                        export PATH="${dracutbasedir}:${PATH}"
+                    fi
                     ;;
                 -H | --hostonly | --host-only)
                     hostonly_l="yes"

--- a/man/dracut-cpio.8.adoc
+++ b/man/dracut-cpio.8.adoc
@@ -1,0 +1,57 @@
+DRACUT-CPIO(8)
+==============
+:doctype: manpage
+:man source:   dracut
+:man manual:   dracut
+
+NAME
+----
+dracut-cpio - builds cpio archives, optimized for copy-on-write filesystems
+
+SYNOPSIS
+--------
+**dracut-cpio** [_OPTIONS_...] _OUTPUT_
+
+DESCRIPTION
+-----------
+dracut-cpio builds cpio archives, optimized for copy-on-write filesystems by
+using the man:copy_file_range[2] syscall via Rust's io::copy(). See the
+man:dracut[8] **--enhanced-cpio** option. _OUTPUT_ is the path of the cpio
+archive to create. The list of files to include is read from stdin.
+
+**Note:** This is a dracut internal tool, do not expect a stable interface
+across versions.
+
+OPTIONS
+-------
+**--data-align** _ALIGNMENT_::
+    Attempt to pad archive to achieve _ALIGNMENT_ (in bytes) for file data.
+
+**-0**, **--null**::
+    Expect null delimiters in stdin filename list instead of newline.
+
+**--mtime** _EPOCH_::
+    Use _EPOCH_ for archived mtime instead of filesystem reported values.
+
+**--owner** _UID:GID_::
+    Use _UID_ and _GID_ instead of filesystem reported owner values.
+
+**--truncate-existing**::
+    Truncate and overwrite any existing _OUTPUT_ file, instead of appending.
+
+**-h**, **--help**::
+    Print help message.
+
+EXAMPLE
+-------
+
+`cd fs-tree && find . -print0 | dracut-cpio -0 ../archive.cpio`
+
+AVAILABILITY
+------------
+The dracut-cpio command is part of the dracut package and is available from
+link:$$https://github.com/dracut-ng/dracut$$[https://github.com/dracut-ng/dracut]
+
+SEE ALSO
+--------
+man:dracut[8]

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -387,8 +387,8 @@ Default:
     _/var/log/dracut.log_
 
 **-l, --local**::
-    Activates the local mode. dracut will use modules from the current working
-    directory instead of the system-wide installed modules in
+    Activates local mode. Dracut will use modules and executables from the
+    current working directory instead of the system-wide installed modules in
     _/usr/lib/dracut/modules.d_.
     This is useful when running dracut from a git checkout.
 

--- a/src/dracut-cpio/src/main.rs
+++ b/src/dracut-cpio/src/main.rs
@@ -632,7 +632,7 @@ fn params_process(props: &mut ArchiveProperties) -> argument::Result<PathBuf> {
         Argument::short_flag(
             '0',
             "null",
-            "Expect null delimeters in stdin filename list instead of newline.",
+            "Expect null delimiters in stdin filename list instead of newline.",
         ),
         Argument::value(
             "mtime",

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -8,10 +8,7 @@ TEST_DESCRIPTION="kernel cpio extraction tests for dracut-cpio"
 # see dracut-cpio source for unit tests
 
 test_check() {
-    if ! [[ -x "$PKGLIBDIR/dracut-cpio" ]]; then
-        echo "Test needs dracut-cpio... Skipping"
-        return 1
-    fi
+    require_binaries_for_test dracut-cpio
 }
 
 test_dracut_cpio() {
@@ -56,6 +53,9 @@ EOF
 }
 
 test_run() {
+    if [[ ${V-} -ge 1 ]]; then
+        echo "found dracut-cpio: $(command -v dracut-cpio)"
+    fi
     # dracut-cpio is typically used with compression and strip disabled, to
     # increase the chance of (reflink) extent sharing.
     test_dracut_cpio "simple" "--no-compress" "--nostrip"

--- a/test/test-functions
+++ b/test/test-functions
@@ -17,6 +17,13 @@ if [[ -z ${basedir-} ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
+if [ "$PKGLIBDIR" = "$basedir" ] && [ -x "$basedir/dracut.sh" ]; then
+    # running for a local build, extend PATH so executables from build will be
+    # used
+    PATH="$(realpath "${basedir}"):${PATH}"
+    export PATH
+fi
+
 if [[ -f /etc/machine-id ]]; then
     read -r TOKEN < /etc/machine-id || :
 fi


### PR DESCRIPTION
As discussed in #2588, installing tools used to build an initramfs to `bindir` and expecting them on `PATH` makes it easier to replace them in a cross-build situtation, specifically: if dracut is installed in a cross-sysroot (so running scripts from the sysroot works, but running executables does not). If tools are installed to `PATH` dracut can transparently use tools installed on the host, and users can adjust `PATH` if they want a specific version, or have dracut installed in a non-default location (e.g. a development build instead of installed distro package).

This PR moves `dracut-cpio`, and adds a manpage for it (based on its `--help` output).

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
