### PR TITLE
feat: build C binaries in top-level directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,8 @@
 /dracut-util
 /dracut.conf.d/*.conf
 /dracut.pc
+/extractinitrd
 /src/dracut-cpio/target/
-/src/extractinitrd/extractinitrd
-/src/install/dracut-install
-/src/util/util
 /test/*/*.html
 /test/*/*.log
 /test/*/.testdir*

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ manpages = $(man1pages) $(man5pages) $(man7pages) $(man8pages)
 
 .PHONY: install clean distclean archive test all check AUTHORS CONTRIBUTORS doc
 
-all: dracut.pc dracut-install src/extractinitrd/extractinitrd dracut-util
+all: dracut.pc extractinitrd dracut-install dracut-util
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(KMOD_CFLAGS) $(SYSTEMD_CFLAGS) $(if $(SYSTEMD_LIBS),-DHAVE_SYSTEMD) $< -o $@
@@ -84,21 +84,16 @@ src/install/log.o: src/install/log.c src/install/log.h src/install/macro.h src/i
 src/install/util.o: src/install/util.c src/install/util.h src/install/macro.h src/install/log.h
 src/install/strv.o: src/install/strv.c src/install/strv.h src/install/util.h src/install/macro.h src/install/log.h
 
-src/install/dracut-install: $(DRACUT_INSTALL_OBJECTS)
-	$(CC) $(LDFLAGS) -o $@ $(DRACUT_INSTALL_OBJECTS) $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS) $(SYSTEMD_LIBS)
-
-dracut-install: src/install/dracut-install
-	ln -fs $< $@
+dracut-install: $(DRACUT_INSTALL_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS) $(SYSTEMD_LIBS)
 
 EXTRACTINITRD_OBJECTS = src/extractinitrd/extractinitrd.o
-src/extractinitrd/extractinitrd: $(EXTRACTINITRD_OBJECTS)
+extractinitrd: $(EXTRACTINITRD_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $^
 
 UTIL_OBJECTS = src/util/util.o
-util/util.o: src/util/util.c
-util/util: $(UTIL_OBJECTS)
-
-dracut-util: src/util/util
-	cp -a $< $@
+dracut-util: $(UTIL_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $^
 
 .PHONY: indent-c
 indent-c:
@@ -252,11 +247,11 @@ endif
 		ln -sf ../dracut-initqueue.service \
 		$(DESTDIR)$(systemdsystemunitdir)/initrd.target.wants/dracut-initqueue.service; \
 	fi
-	if [ -f src/install/dracut-install ]; then \
-		install -m 0755 src/install/dracut-install $(DESTDIR)$(pkglibdir)/dracut-install; \
+	if [ -f dracut-install ]; then \
+		install -m 0755 dracut-install $(DESTDIR)$(pkglibdir)/dracut-install; \
 	fi
-	if [ -f src/extractinitrd/extractinitrd ]; then \
-		install -m 0755 src/extractinitrd/extractinitrd $(DESTDIR)$(pkglibdir)/extractinitrd; \
+	if [ -f extractinitrd ]; then \
+		install -m 0755 extractinitrd $(DESTDIR)$(pkglibdir)/extractinitrd; \
 	fi
 	if [ -f dracut-util ]; then \
 		install -m 0755 dracut-util $(DESTDIR)$(pkglibdir)/dracut-util; \
@@ -296,9 +291,9 @@ clean:
 	$(RM) */*/*~
 	$(RM) $(manpages:%=%.xml) dracut.xml
 	$(RM) dracut-*.tar.bz2 dracut-*.tar.xz
-	$(RM) dracut-install src/install/dracut-install $(DRACUT_INSTALL_OBJECTS)
-	$(RM) src/extractinitrd/extractinitrd $(EXTRACTINITRD_OBJECTS)
-	$(RM) dracut-util src/util/util $(UTIL_OBJECTS)
+	$(RM) dracut-install $(DRACUT_INSTALL_OBJECTS)
+	$(RM) extractinitrd $(EXTRACTINITRD_OBJECTS)
+	$(RM) dracut-util $(UTIL_OBJECTS)
 	$(RM) $(manpages)
 	$(RM) dracut.pc
 	$(RM) dracut-cpio src/dracut-cpio/target/release/dracut-cpio*

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1562,8 +1562,6 @@ fi
 
 if ! [[ $DRACUT_INSTALL ]] && [[ -x "${BASH_SOURCE[0]%/*}/dracut-install" ]]; then
     DRACUT_INSTALL="${BASH_SOURCE[0]%/*}/dracut-install"
-elif ! [[ $DRACUT_INSTALL ]] && [[ -x "${BASH_SOURCE[0]%/*}/src/install/dracut-install" ]]; then
-    DRACUT_INSTALL="${BASH_SOURCE[0]%/*}/src/install/dracut-install"
 fi
 
 # Test if the configured dracut-install command exists.

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -111,11 +111,7 @@ if command -v 3cpio > /dev/null; then
     unset threecpio_help_output
 fi
 if ! [[ $EXTRACTOR ]]; then
-    if [[ -f "$dracutbasedir/src/extractinitrd/extractinitrd" ]]; then
-        EXTRACTOR="$dracutbasedir/src/extractinitrd/extractinitrd"
-    else
-        EXTRACTOR="$dracutbasedir/extractinitrd"
-    fi
+    EXTRACTOR="$dracutbasedir/extractinitrd"
     if ! [[ -x $EXTRACTOR ]]; then
         echo
         echo "Error: '$EXTRACTOR' not found, cannot continue!" >&2

--- a/test/TEST-83-EXRACTINITRD/test.sh
+++ b/test/TEST-83-EXRACTINITRD/test.sh
@@ -13,14 +13,6 @@ test_check() {
     require_binaries_for_test cpio diff find gzip
 }
 
-get_extractinitrd_cmd() {
-    if [ "$PKGLIBDIR" = "$basedir" ]; then
-        echo "${PKGLIBDIR}/src/extractinitrd/extractinitrd"
-    else
-        echo "${PKGLIBDIR}/extractinitrd"
-    fi
-}
-
 # Dummy compressor; wrapper for cat that ignores its argument (-c)
 # shellcheck disable=SC2329
 no_compressor() {
@@ -126,7 +118,7 @@ test_full_extraction() {
 
             # Unpack it
             rm -rf "$TESTDIR/output"
-            $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
+            "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
                 echo >&2 'E: extractinitrd failed'
                 return 1
             }
@@ -143,7 +135,7 @@ test_part_extraction() {
 
     echo "I: Testing extracting part 1 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
+    "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
         echo >&2 'E: extractinitrd failed'
         return 1
     }
@@ -151,7 +143,7 @@ test_part_extraction() {
 
     echo "I: Testing extracting part 2 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
+    "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
         echo >&2 'E: extractinitrd failed'
         return 1
     }
@@ -159,7 +151,7 @@ test_part_extraction() {
 
     echo "I: Testing extracting everything except part 1 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    $(get_extractinitrd_cmd) ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
+    "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
         echo >&2 'E: extractinitrd failed'
         return 1
     }
@@ -182,17 +174,17 @@ test_extract_to_stdout() {
     construct_initrd_image "2" "2" "$compressor"
 
     echo "I: Testing pattern does not match anything of initrd with $compressor"
-    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --to-stdout \
+    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- non-existing)
     assert_equal "$metadata" ''
 
     echo "I: Testing extracting early 1 metadata of initrd with $compressor"
-    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --to-stdout \
+    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- kernel/dir0/metadata)
     assert_equal "$metadata" 'early0'
 
     echo "I: Testing extracting two metadata files of initrd with $compressor"
-    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --to-stdout \
+    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- kernel/dir1/metadata dir0/metadata)
     assert_equal "$metadata" $'early1\nmain0'
 }
@@ -203,7 +195,7 @@ test_list() {
     construct_initrd_image "1" "2" "$compressor"
 
     echo "I: Testing list full content of initrd with $compressor"
-    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
+    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
     assert_equal "$metadata" '.
 kernel
 kernel/dir0
@@ -246,7 +238,7 @@ dir1/file9
 dir1/metadata'
 
     echo "I: Testing list part 2 of initrd with $compressor"
-    metadata=$($(get_extractinitrd_cmd) ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
+    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
     assert_equal "$metadata" '.
 dir0
 dir0/file0


### PR DESCRIPTION
Build the C binaries in the top-level directory to simplify the Makefile and the (test) code, because then the top-level directory can act as `PKGLIBDIR`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
