### PR TITLE
fix(Makefile): remove src/dracut-cpio/target/ on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ clean:
 	$(RM) dracut-util $(UTIL_OBJECTS)
 	$(RM) $(manpages)
 	$(RM) dracut.pc
-	$(RM) dracut-cpio src/dracut-cpio/target/release/dracut-cpio*
+	$(RM) dracut-cpio src/dracut-cpio/target/
 	$(RM) -rf build/ doc_site/modules/ROOT/pages/man/*
 	$(MAKE) -C test clean
 


### PR DESCRIPTION
cargo creates `src/dracut-cpio/target` when building. Remove the whole directory on `clean`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
