### PR TITLE
fix(busybox): do not install mke2fs applet

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -39,6 +39,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/33
             continue
         fi
+        if [[ ${_path##*/} == mke2fs ]]; then
+            # e2fsprogs provides mke2fs. mkfs.ext2, mkfs.ext3, and mkfs.ext4 are symlinks to it.
+            # Busybox does not provide a mkfs.ext4 applet and mkfs.ext* would point to busybox then.
+            continue
+        fi
         if [[ ${_path##*/} == mount ]]; then
             # The busybox mount applet does not resolve "auto" to the actual filesystem.
             # See https://github.com/vda-linux/busybox_mirror/issues/34


### PR DESCRIPTION
e2fsprogs provides `mke2fs`. `mkfs.ext2`, `mkfs.ext3`, and `mkfs.ext4` are symlinks to it. Busybox does not provide a `mkfs.ext4` applet and `mkfs.ext*` would point to busybox then. This can be seen when including the busybox module:

```
$ test/test.sh ubuntu:devel 21
[...]
CLIENT TEST START: encrypted overlay (new device, random password)
[...]
[    7.398868] dracut-pre-pivot[289]: Creating ext4 filesystem on /dev/mapper/overlay-crypt
[    7.400071] dracut-pre-pivot[373]: mkfs.ext4: applet not found
```

So do not install the `mke2fs` busybox applet.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
