### PR TITLE
fix(Makefile): use -rf for cleaning src/dracut-cpio/target/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,8 +296,8 @@ clean:
 	$(RM) dracut-util $(UTIL_OBJECTS)
 	$(RM) $(manpages)
 	$(RM) dracut.pc
-	$(RM) dracut-cpio src/dracut-cpio/target/
-	$(RM) -rf build/ doc_site/modules/ROOT/pages/man/*
+	$(RM) dracut-cpio
+	$(RM) -rf build/ doc_site/modules/ROOT/pages/man/* src/dracut-cpio/target/
 	$(MAKE) -C test clean
 
 distclean: clean


### PR DESCRIPTION
Make adds -f automatically, rm still refuses to delete directories without -r.

Fixes: c22d7551b095e02daddb0bd91d898050abd09265

@bdrung 

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
