### PR TITLE
fix(busybox): do not install nbd-client applet

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -44,6 +44,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/34
             continue
         fi
+        if [[ ${_path##*/} == nbd-client ]]; then
+            # The busybox nbd-client applet does not support the option -check.
+            # See https://github.com/vda-linux/busybox_mirror/issues/35
+            continue
+        fi
 
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names


### PR DESCRIPTION
The busybox `nbd-client` applet does not support the option `-check` and others. This causes the test 60-NFS to fail with busybox.

So not install the `nbd-client` applet.

Fixes: https://github.com/dracut-ng/dracut/issues/2677

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
