### PR TITLE
refactor(shell-interpreter): order list of modules

### DIFF
--- a/modules.d/85shell-interpreter/module-setup.sh
+++ b/modules.d/85shell-interpreter/module-setup.sh
@@ -7,10 +7,8 @@
 # due to the dependencies below, this dracut module needs to be ordered later than the bash, dash and busybox dracut modules
 
 depends() {
-    # priority order
-    shells='bash dash busybox'
-
-    for shell in $shells; do
+    # The priority order is by module order: bash busybox dash
+    for shell in bash busybox dash; do
         if dracut_module_included "$shell"; then
             echo "$shell"
             return 0


### PR DESCRIPTION
In case both modules `busybox` and `dash` are included in the initrd, the module order decides which of those will provide `/bin/sh`. Since all shells `bash`, `busybox`, and `dash` have number 10 they will be order alphabetical. This is the preferred order: bash is the most powerful shell, busybox is more comfortable to use than dash.

Order the list of modules to check and clarify the comment.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
