### PR TITLE
fix: support umount applet from busybox

### DIFF
--- a/modules.d/68lvmmerge/lvmmerge.sh
+++ b/modules.d/68lvmmerge/lvmmerge.sh
@@ -8,7 +8,18 @@ do_merge() {
 
     systemctl --no-block stop sysroot.mount
     swapoff -a
-    umount -R /sysroot
+
+    # busybox does not support umount --recursive
+    local target
+    sed '1!G;h;$!d' /proc/self/mountinfo | while read -r _ _ _ _ target _; do
+        case "$target" in
+            /sysroot | /sysroot/*)
+                target=$(printf '%b_' "$target")
+                target=${target%_}
+                umount "$target"
+                ;;
+        esac
+    done
 
     for tag in $(getargs rd.lvm.mergetags); do
         lvm vgs --noheadings -o vg_name \

--- a/modules.d/70dmsquash-live/apply-live-updates.sh
+++ b/modules.d/70dmsquash-live/apply-live-updates.sh
@@ -17,6 +17,6 @@ fi
 # release resources on iso-scan boots with rd.live.ram
 if [ -d /run/initramfs/isoscan ] \
     && [ -f /run/initramfs/squashed.img ] || [ -f /run/initramfs/rootfs.img ]; then
-    umount --detach-loop /run/initramfs/live
+    umount -d /run/initramfs/live
     umount /run/initramfs/isoscan
 fi

--- a/modules.d/77selinux/selinux-loadpolicy.sh
+++ b/modules.d/77selinux/selinux-loadpolicy.sh
@@ -46,7 +46,19 @@ rd_load_policy() {
             [ -e "$NEWROOT"/.autorelabel ] && LANG=C /usr/sbin/setenforce 0
             mount --rbind /dev "$NEWROOT/dev"
             LANG=C chroot "$NEWROOT" /sbin/restorecon -R /dev
-            umount -R "$NEWROOT/dev"
+
+            # busybox does not support umount --recursive
+            local target
+            sed '1!G;h;$!d' /proc/self/mountinfo | while read -r _ _ _ _ target _; do
+                case "$target" in
+                    "$NEWROOT"/dev | "$NEWROOT"/dev/*)
+                        target=$(printf '%b_' "$target")
+                        target=${target%_}
+                        umount "$target"
+                        ;;
+                esac
+            done
+
             return 0
         fi
 


### PR DESCRIPTION
busybox's `umount` applet does not support the long form `--detach-loop` but it supports the short form `-d`.

The busybox `umount` applet does not support the option `-R`/`--recursive`.

Implement the recursive unmounting in shell by reverse iterating over `/proc/self/mountinfo` and unmounting matching paths.

Fixes: https://github.com/dracut-ng/dracut/issues/2684 \
Part of: https://github.com/dracut-ng/dracut/issues/2437

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
