### PR TITLE
fix(busybox): do not install sulogin applet

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -54,6 +54,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/35
             continue
         fi
+        if [[ ${_path##*/} == sulogin ]]; then
+            # The busybox sulogin applet does not support the option -e.
+            # See https://github.com/vda-linux/busybox_mirror/issues/36
+            continue
+        fi
 
         # if busybox is built without CONFIG_FEATURE_INSTALLER=y, the list
         # has only plain names


### PR DESCRIPTION
The busybox `sulogin` applet does not support the option `-e`

Fixes: https://github.com/dracut-ng/dracut/issues/2678
Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
