### PR TITLE
fix(busybox): do not install losetup applet

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -39,6 +39,11 @@ install() {
             # See https://github.com/vda-linux/busybox_mirror/issues/33
             continue
         fi
+        if [[ ${_path##*/} == losetup ]]; then
+            # The busybox losetup applet does not support the option --show.
+            # See https://github.com/vda-linux/busybox_mirror/issues/37
+            continue
+        fi
         if [[ ${_path##*/} == mke2fs ]]; then
             # e2fsprogs provides mke2fs. mkfs.ext2, mkfs.ext3, and mkfs.ext4 are symlinks to it.
             # Busybox does not provide a mkfs.ext4 applet and mkfs.ext* would point to busybox then.


### PR DESCRIPTION
The busybox `losetup` applet does not support the option `--show`.

Fixes: https://github.com/dracut-ng/dracut/issues/2675
Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
