### PR TITLE
fix(base): drop replacing switch_root from busybox

### DIFF
--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -97,14 +97,6 @@ install() {
     inst_simple "$moddir/insmodpost.sh" /sbin/insmodpost.sh
 
     if ! dracut_module_included "systemd"; then
-        # Prefer the host's util-linux switch_root over the busybox
-        # applet. When the busybox dracut module is included it runs first and
-        # may have symlinked switch_root to its applet. Drop that symlink so
-        # the host binary is installed instead
-        if dracut_module_included "busybox"; then
-            rm -f "${initdir}/bin/switch_root" "${initdir}/sbin/switch_root" \
-                "${initdir}/usr/bin/switch_root" "${initdir}/usr/sbin/switch_root"
-        fi
         inst_multiple switch_root || dfatal "Failed to install switch_root"
         inst_script "$moddir/init.sh" "/init"
         inst_hook cmdline 01 "$moddir/parse-kernel.sh"

--- a/test/TEST-15-BUSYBOX/test.sh
+++ b/test/TEST-15-BUSYBOX/test.sh
@@ -61,13 +61,6 @@ test_run() {
     # Each must resolve to busybox in the resulting initrd.
     check_applets_from_busybox "$TESTDIR/initramfs.testing" ash cp ip ls mv mkdir sleep tr || ret=1
 
-    # switch_root must NOT be a busybox symlink as the base module reinstalls
-    # the host util-linux version on top of any symlink the busybox module left
-    if lsinitrd "$TESTDIR/initramfs.testing" | grep -E '^l.* switch_root -> .*busybox'; then
-        echo "FAIL: switch_root is a busybox symlink, host version was not preserved" >&2
-        ret=1
-    fi
-
     declare -a disk_args=()
     qemu_add_drive disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_args "$TESTDIR"/root.img root


### PR DESCRIPTION
In 2010 commit dbcc4e94c54dd386f09ba0709cb42592cc739502 ("Add busybox shell replacements module") skipped installing the `switch_root` applet from busybox with the reason:

> FIXME: switch_root should be in the above list, but busybox version hangs (using busybox-1.15.1-7.fc14.i686 at the time of writing)

Assume that the recent busybox versions do not hang.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
