### PR TITLE
feat: add --prefer option and prefer busybox on Debian/Ubuntu

### DIFF
--- a/dracut.conf.d/debian/01-debian.conf
+++ b/dracut.conf.d/debian/01-debian.conf
@@ -1,3 +1,4 @@
 # Debian/Ubuntu specific Dracut configuration
 i18n_vars="/etc/locale.conf:LANG /etc/default/console-setup:FONT,FONT_MAP,CONSOLE_MAP-FONT_UNIMAP /etc/default/keyboard:XKBLAYOUT-KEYMAP,XKBVARIANT-EXT_KEYMAPS"
 initrdname="initrd.img-${kernel}"
+prefer_dracutmodules+=" busybox "

--- a/dracut.sh
+++ b/dracut.sh
@@ -96,6 +96,8 @@ Creates initial ramdisk images for preloading modules
   --force-add [LIST]    Force to add a space-separated list of dracut modules
                          to the default set of modules, when -H is specified.
   -o, --omit [LIST]     Omit a space-separated list of dracut modules.
+  --prefer [LIST]       Specify a space-separated list of dracut modules that
+                         will be added if their preconditions are met.
   -m, --modules [LIST]  Specify a space-separated list of dracut modules to
                          call when building the initramfs. Modules are located
                          in /usr/lib/dracut/modules.d.
@@ -392,6 +394,7 @@ rearrange_params() {
             --long add-drivers: \
             --long force-drivers: \
             --long omit-drivers: \
+            --long prefer: \
             --long modules: \
             --long omit: \
             --long drivers: \
@@ -595,6 +598,7 @@ no_kernel=
 nofscks=
 omit_dracutmodules=
 omit_drivers=
+prefer_dracutmodules=
 prefix=
 ro_mnt=
 squash_compress=
@@ -693,6 +697,11 @@ while :; do
                     ;;
                 -o | --omit)
                     omit_dracutmodules_l+=("$2")
+                    PARMS_TO_STORE+=" '$2'"
+                    shift
+                    ;;
+                --prefer)
+                    prefer_dracutmodules_l+=("$2")
                     PARMS_TO_STORE+=" '$2'"
                     shift
                     ;;
@@ -1126,6 +1135,7 @@ export SYSTEMCTL=${SYSTEMCTL:-systemctl}
 ((${#add_dracutmodules_l[@]})) && add_dracutmodules+=" ${add_dracutmodules_l[*]} "
 ((${#omit_dracutmodules_l[@]})) && omit_dracutmodules+=" ${omit_dracutmodules_l[*]} "
 ((${#force_add_dracutmodules_l[@]})) && force_add_dracutmodules+=" ${force_add_dracutmodules_l[*]} "
+((${#prefer_dracutmodules_l[@]})) && prefer_dracutmodules+=" ${prefer_dracutmodules_l[*]} "
 ((${#fscks_l[@]})) && fscks+=" ${fscks_l[*]} "
 ((${#add_fstab_l[@]})) && add_fstab+=" ${add_fstab_l[*]} "
 ((${#install_items_l[@]})) && install_items+=" ${install_items_l[*]} "
@@ -1863,7 +1873,7 @@ check_module() {
         fi
     fi
 
-    if [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules" == *\ $_mod\ * ]]; then
+    if [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules $prefer_dracutmodules" == *\ $_mod\ * ]]; then
         if [[ " $dracutmodules $force_add_dracutmodules " == *\ $_mod\ * ]]; then
             module_check "$_mod" 1 "$_moddir"
             _ret=$?
@@ -1871,7 +1881,7 @@ check_module() {
             module_check "$_mod" 0 "$_moddir"
             _ret=$?
         fi
-        # explicit module, so also accept _ret=255
+        # explicit or preferred module, so accept _ret=0 and _ret=255
         [[ $_ret == 0 || $_ret == 255 ]] || return 1
     else
         # module not in our list
@@ -1897,6 +1907,9 @@ check_module() {
         [[ " $add_dracutmodules " == *\ $_mod\ * ]] \
             && [[ " $add_dracutmodules " != *\ $_moddep\ * ]] \
             && add_dracutmodules+=" $_moddep "
+        [[ " $prefer_dracutmodules " == *\ $_mod\ * ]] \
+            && [[ " $prefer_dracutmodules " != *\ $_moddep\ * ]] \
+            && prefer_dracutmodules+=" $_moddep "
         [[ " $force_add_dracutmodules " == *\ $_mod\ * ]] \
             && [[ " $force_add_dracutmodules " != *\ $_moddep\ * ]] \
             && force_add_dracutmodules+=" $_moddep "
@@ -2597,6 +2610,7 @@ if [[ $printconfig ]]; then
         nofscks \
         omit_dracutmodules \
         omit_drivers \
+        prefer_dracutmodules \
         prefix \
         ro_mnt \
         squash_compress \

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -117,6 +117,22 @@ example:
 ----
 ===============================
 
+**--prefer** _<list of dracut modules>_::
+    Add a space-separated list of dracut modules to be preferred. Preferred modules
+    will be included if they are supported by your system, but safely skipped if
+    they are not compatible or have missing dependencies.
+    If a module appears in both _prefer_ and _omit_ lists, it will be omitted.
+    This parameter can be specified multiple times.
++
+[NOTE]
+===============================
+If the list has multiple arguments, then you have to put these in quotes. For
+example:
+----
+# dracut --prefer "module1 module2"  ...
+----
+===============================
+
 **-m, --modules** _<list of dracut modules>_::
     Specify a space-separated list of dracut modules to call when building the
     initramfs. Modules are located in _/usr/lib/dracut/modules.d_. This

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -50,6 +50,10 @@ WARNING: Avoid manually omitting dracut modules, as you may inadvertently
 remove essential ones that dracut can't detect or warn you about. Using this
 option is not recommended and is at your own risk.
 
+*prefer_dracutmodules+=*" __<dracut modules>__ "::
+Specify a space-separated list of dracut modules that will be added
+if their preconditions are met.
+
 *dracutmodules+=*" __<dracut modules>__ "::
 Specify a space-separated list of dracut modules to call when building the
 initramfs. Modules are located in _/usr/lib/dracut/modules.d_.

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -40,7 +40,7 @@ _dracut() {
             --no-uefi --no-ukify --no-machineid --version --parallel --printconfig
             '
         [ARG]='-a -m -o -d -I -k -c -L -r -i
-            --kver --add --force-add --add-drivers --force-drivers
+            --kver --add --force-add --add-drivers --force-drivers --prefer
             --omit-drivers --modules --omit --drivers --filesystems --install
             --fwdir --libdirs --fscks --add-fstab --mount --device
             --kmoddir --conf --confdir --tmpdir --stdlog --compress --prefix
@@ -63,7 +63,7 @@ _dracut() {
                 comps=$(compgen -f -- "$cur")
                 compopt -o filenames
                 ;;
-            -a | -m | -o | --add | --modules | --omit)
+            -a | -m | -o | --add | --modules | --omit | --prefer)
                 comps=$(dracut --list-modules 2> /dev/null)
                 ;;
             --compress-level)

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -24,7 +24,10 @@ umount /root/usr
 mount -t btrfs -o subvol=usr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 mount --bind /root/usr /root_crypt/usr
 cp -a -t /root /source/*
-cp -a -t /root_crypt /source/*
+for path in /source/*; do
+    [ "${path##*/}" = usr ] && continue
+    cp -a "$path" /root_crypt
+done
 mkdir -p /root/run /root_crypt/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root


### PR DESCRIPTION
Add a `--prefer` option and a `prefer_dracutmodules` config option to specify Dracut modules that should be included if their preconditions are met.

Include busybox on Debian/Ubuntu if available. This reduces the size of the initrd significantly. Some data for Ubuntu 26.04 LTS "resolute" using the current `ubuntu:rolling` container with a modified test 10. The data is collected with `ls -l` and `3cpio --examine`.

## Without plymouth

An initrd without plymouth and without busybox uses 42.0 MB (42001866 bytes) when zstd compressed:

```
Start     End       Size      Compr.   Extracted
0 B       92.0 kB   92.0 kB   cpio     91.1 kB
92.0 kB   17.3 MB   17.2 MB   cpio     17.0 MB
17.3 MB   42.0 MB   24.7 MB   zstd     77.9 MB
```

The same initrd with busybox needs only 37.9 MB (37861705 bytes) when zstd compressed:

```
Start     End       Size      Compr.   Extracted
0 B       92.0 kB   92.0 kB   cpio     91.1 kB
92.0 kB   17.3 MB   17.2 MB   cpio     17.0 MB
17.3 MB   37.9 MB   20.6 MB   zstd     65.4 MB
```

So 4.1 MB (9.9 %) disk space is saved and 12.5 MB (16.0 %) memory after decompression is saved.

## With plymouth

An initrd with plymouth and without busybox uses 49.5 MB (49493709 bytes) when zstd compressed:

```
Start     End       Size      Compr.   Extracted
0 B       92.0 kB   92.0 kB   cpio     91.1 kB
92.0 kB   17.3 MB   17.2 MB   cpio     17.1 MB
17.3 MB   49.5 MB   32.2 MB   zstd     99.4 MB
```

The same initrd with busybox needs only 45.3 MB (45348147 bytes) when zstd compressed:

```
Start     End       Size      Compr.   Extracted
0 B       92.0 kB   92.0 kB   cpio     91.1 kB
92.0 kB   17.3 MB   17.2 MB   cpio     17.1 MB
17.3 MB   45.3 MB   28.0 MB   zstd     86.9 MB
```

So 4.1 MB (8.4 %) disk space is saved and 12.5 MB (12.6 %) memory after decompression is saved.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/2150657

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
