### PR TITLE
test: drop preferring the coreutils version of dd

### DIFF
--- a/test/modules.d/70test-makeroot/module-setup.sh
+++ b/test/modules.d/70test-makeroot/module-setup.sh
@@ -10,10 +10,6 @@ depends() {
 }
 
 install() {
-    inst_multiple cp umount sync mkfs.ext4
-
-    # prefer the coreutils version of dd over the busybox version for testing
-    inst /bin/dd /usr/sbin/dd
-
+    inst_multiple cp dd umount sync mkfs.ext4
     inst_hook initqueue/finished 01 "$moddir/finished-false.sh"
 }


### PR DESCRIPTION
Commit adb119676646d25e9f5eb8fd81e1bf00d612022a ("ci: run the extended tests the same way as basic tests") added the code to prefer the coreutils version of dd over the busybox version for testing, but gave no reason for it.

The `dd` applet from busybox should be sufficient and no special unsupported options are used in Dracut. So drop preferring the coreutils version of dd.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
