### PR TITLE
test(DMSQUASH): always test xorriso

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -10,7 +10,7 @@ TEST_DESCRIPTION="live root on a squash filesystem"
 #DEBUGFAIL="rd.shell rd.debug rd.live.debug loglevel=7"
 
 test_check() {
-    require_binaries_for_test mksquashfs
+    require_binaries_for_test mksquashfs xorriso
 }
 
 client_run() {
@@ -78,10 +78,7 @@ test_run() {
         client_run "erofs" "root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs"
     fi
 
-    # Run the iso test only if xorriso is available
-    if command -v xorriso &> /dev/null; then
-        client_run "iso" "iso-scan/filename=linux.iso root=live:/dev/disk/by-label/ISO rd.driver.pre=squashfs rd.driver.pre=ext4"
-    fi
+    client_run "iso" "iso-scan/filename=linux.iso root=live:/dev/disk/by-label/ISO rd.driver.pre=squashfs rd.driver.pre=ext4"
 
     reset_overlay_partition
     client_run "autooverlay" "rd.live.image rd.overlay=LABEL=persist rd.live.dir=LiveOS"
@@ -131,11 +128,9 @@ EOF
     qemu_add_drive disk_args "$TESTDIR"/root_iso.img root_iso 1
 
     # Write the iso to the partition
-    if command -v xorriso &> /dev/null; then
-        mkdir "$TESTDIR"/iso
-        xorriso -as mkisofs -output "$TESTDIR"/iso/linux.iso "$TESTDIR"/live/ -volid "ISO" -iso-level 3
-        mkfs.ext4 -q -L dracut_iso -d "$TESTDIR"/iso/ "$TESTDIR"/root_iso.img
-    fi
+    mkdir "$TESTDIR"/iso
+    xorriso -as mkisofs -output "$TESTDIR"/iso/linux.iso "$TESTDIR"/live/ -volid "ISO" -iso-level 3
+    mkfs.ext4 -q -L dracut_iso -d "$TESTDIR"/iso/ "$TESTDIR"/root_iso.img
 
     local dracut_modules="dmsquash-live-autooverlay convertfs pollcdrom kernel-modules kernel-modules-extra qemu"
 


### PR DESCRIPTION
All containers have `xorriso` installed. So simplify the test code by requiring `xorriso` to be present.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
