### PR TITLE
fix(dracut): correct order of "Creating image" log line

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3133,8 +3133,6 @@ if [[ -e $outfile ]]; then
     outfile="${outfile}.tmp"
 fi
 
-dinfo "*** Creating image file '$outfile' ***"
-
 # Read list of files and echo them plus all leading directories.
 # The same directories might be printed multiple times (even with sorted input)!
 add_directories() {
@@ -3202,6 +3200,8 @@ if [[ $do_hardlink == yes ]] && command -v hardlink > /dev/null; then
         clamp_mtimes "$initdir" -type d
     fi
 fi
+
+dinfo "*** Creating image file '$outfile' ***"
 
 [[ $EUID != 0 ]] && cpio_owner="0:0"
 


### PR DESCRIPTION
The log line "Creating image" is followed by "Hardlinking files":

```
[...]
dracut[I]: *** Including modules done ***
dracut[I]: *** Installing kernel module dependencies ***
dracut[I]: *** Installing kernel module dependencies done ***
dracut[I]: *** Resolving dependencies for executables and libraries ***
dracut[I]: *** Resolving dependencies for executables and libraries done ***
dracut[I]: *** Generating early-microcode cpio image ***
dracut[I]: *** Constructing GenuineIntel.bin ***
dracut[I]: *** Store current command line parameters ***
dracut[I]: *** Stripping files ***
dracut[I]: *** Stripping files done ***
dracut[I]: *** Creating image file '/var/tmp/dracut-test.doZhty/initramfs.testing' ***
dracut[I]: *** Hardlinking files ***
dracut[I]: *** Hardlinking files done ***
dracut[I]: Using auto-determined compression method 'zstd'
dracut[I]: *** Creating initramfs image file '/var/tmp/dracut-test.doZhty/initramfs.testing' done ***
```

Move the "Creating image" log line back to where it belonged:

```
[...]
dracut[I]: *** Including modules done ***
dracut[I]: *** Installing kernel module dependencies ***
dracut[I]: *** Installing kernel module dependencies done ***
dracut[I]: *** Resolving dependencies for executables and libraries ***
dracut[I]: *** Resolving dependencies for executables and libraries done ***
dracut[I]: *** Generating early-microcode cpio image ***
dracut[I]: *** Constructing GenuineIntel.bin ***
dracut[I]: *** Store current command line parameters ***
dracut[I]: *** Stripping files ***
dracut[I]: *** Stripping files done ***
dracut[I]: *** Hardlinking files ***
dracut[I]: *** Hardlinking files done ***
dracut[I]: *** Creating image file '/var/tmp/dracut-test.nfRABi/initramfs.testing' ***
dracut[I]: Using auto-determined compression method 'zstd'
dracut[I]: *** Creating initramfs image file '/var/tmp/dracut-test.nfRABi/initramfs.testing' done ***
```

Fixes: 9fdf683f6d2 ("fix(dracut): ensure hardlink deduplication is reproducible")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
