### PR TITLE
fix(dracut-install): refuse empty values for env vars that need a value

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -2605,7 +2605,7 @@ static int install_modules(int argc, char **argv)
                 char *modalias_file;
                 modalias_file = getenv("DRACUT_KERNEL_MODALIASES");
 
-                if (modalias_file == NULL) {
+                if (isempty(modalias_file)) {
                         modalias_list(ctx);
                 } else {
                         _cleanup_fclose_ FILE *f = NULL;
@@ -2967,10 +2967,10 @@ int main(int argc, char **argv)
                 log_debug("%s", argv[r]);
 
         path = getenv("DRACUT_INSTALL_PATH");
-        if (path == NULL)
+        if (isempty(path))
                 path = getenv("PATH");
 
-        if (path == NULL) {
+        if (isempty(path)) {
                 log_error("PATH is not set");
                 exit(EXIT_FAILURE);
         }


### PR DESCRIPTION
Fixes #683.

Two env-var hardening fixes in `dracut-install`, following the pattern of `a9e1144` ("refuse empty DRACUT_LDD"):

- `DRACUT_INSTALL_PATH` / `PATH`: an empty value previously slipped through (`getenv` returns non-NULL), leaving the binary with no search roots and failing later without a useful diagnostic. Now empty `DRACUT_INSTALL_PATH` falls back to `PATH`, and an empty `PATH` errors out immediately (`PATH is not set`, `exit 1`).
- `DRACUT_KERNEL_MODALIASES`: with an empty value, `fopen("")` silently failed, producing an empty hostonly module list. Now empty falls back to `modalias_list()` — same behavior as the variable being unset.

Deliberately **not** changed, per the issue discussion:
- `DRACUT_FIRMWARE_PATH` — empty is useful (skip firmware copy).
- `DRACUT_NO_XATTR` — takes no value.

### Local test

```
$ env -i DRACUT_INSTALL_PATH="" dracut-install -D "$R" -a uname
# before: silent exit 1 (no diagnostic)
# after:  "dracut-install: PATH is not set" + exit 1

$ env -i DRACUT_INSTALL_PATH="" PATH=/usr/bin:/usr/sbin dracut-install -D "$R" -a uname
# after: succeeds, uname installed — empty DRACUT_INSTALL_PATH now falls back

$ env -i ... DRACUT_KERNEL_MODALIASES="" dracut-install --hostonly -D "$R" -m <mod>
# before: fopen("") silently fails, treated as "no modalias list"
# after:  falls back to the kernel's modalias list, same as unset
```
No build warnings (`-Wall -Wextra`).
