### PR TITLE
perf(lsinitrd): call extractor only once in extract_squash_img

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -221,6 +221,17 @@ cpio_extract() {
 }
 
 # Takes optional pattern arguments
+cpio_extract_to_directory() {
+    local directory="$1"
+    shift
+    if [ "$EXTRACTOR" = 3cpio ]; then
+        3cpio --extract -C "$directory" --make-directories --parts "$parts" $verbose "$image" -- "$@"
+    else
+        "$EXTRACTOR" -D "$directory" --parts "$parts" $verbose "$image" -- "$@"
+    fi
+}
+
+# Takes optional pattern arguments
 cpio_extract_to_stdout() {
     if [ "$EXTRACTOR" = 3cpio ]; then
         3cpio --extract --parts "$parts" --to-stdout "$image" -- "$@"
@@ -244,13 +255,14 @@ extract_squash_img() {
     [[ $SQUASH_TMPDIR == none ]] && return 1
     [[ -s $SQUASH_TMPFILE ]] && return 0
 
+    cpio_extract_to_directory "$TMPDIR" squash-root.img squashfs-root.img erofs-root.img
+
     # Before dracut 104 the image was named squash-root.img. Keep the old name
     # so newer versions of lsinitrd can inspect initrds build with older dracut
     # versions.
     for _img in squash-root.img squashfs-root.img erofs-root.img; do
         _tmp="$TMPDIR/$_img"
-        cpio_extract_to_stdout "$_img" > "$_tmp"
-        [[ -s $_tmp ]] || continue
+        [[ -s $_tmp && -f $_tmp ]] || continue
 
         SQUASH_TMPFILE="$_tmp"
 


### PR DESCRIPTION
Calling the extractor (`3cpio` or `extractinitrd`) is expensive. `extract_squash_img` calls the extract three times; once per possible squashfs/erofs file.

Call the extractor only once in `extract_squash_img` to extract all three files in one go. A normal initrd only ships one squashfs/erofs file.

Benchmark result on my desktop machine running Ubuntu 26.04:

```
$ hyperfine -L commit 3948f63c,speedup-lsinitrd -p "git checkout {commit}" -w 1 "sudo ./lsinitrd.sh /boot/initrd.img"
Benchmark 1: sudo ./lsinitrd.sh /boot/initrd.img (commit = 3948f63c)
  Time (mean ± σ):     571.7 ms ±   3.2 ms    [User: 2.5 ms, System: 3.0 ms]
  Range (min … max):   565.7 ms … 576.5 ms    10 runs

Benchmark 2: sudo ./lsinitrd.sh /boot/initrd.img (commit = speedup-lsinitrd)
  Time (mean ± σ):     433.4 ms ±   5.2 ms    [User: 2.0 ms, System: 3.4 ms]
  Range (min … max):   426.6 ms … 444.3 ms    10 runs

Summary
  sudo ./lsinitrd.sh /boot/initrd.img (commit = speedup-lsinitrd) ran
    1.32 ± 0.02 times faster than sudo ./lsinitrd.sh /boot/initrd.img (commit = 3948f63c)
```

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
