### PR TITLE
fix(systemd-cryptsetup): check all crypttab entries for socket key files

### DIFF
--- a/modules.d/71systemd-cryptsetup/module-setup.sh
+++ b/modules.d/71systemd-cryptsetup/module-setup.sh
@@ -73,7 +73,7 @@ install() {
         while read -r _mapper _dev _luksfile _luksoptions || [[ -n $_mapper ]]; do
             # ignore paths followed by a device specification
             if [[ $_luksfile == *":"* ]]; then
-                return
+                continue
             fi
 
             # if no explicit path is provided, try to include units for auto-discoverable keys


### PR DESCRIPTION
The loop calls `return` where `continue` is meant, which exits `install()` on the first "keyfile:device" found.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
