### PR TITLE
fix(dmsquash-live): support blkid applet from busybox

### DIFF
--- a/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
@@ -70,11 +70,19 @@ gatherData() {
 
     overlayPartition=${blockDevice}$((currentPartitionCount + 1))
 
-    label=$(blkid --match-tag LABEL --output value "$rootDevice")
-    uuid=$(blkid --match-tag UUID --output value "$rootDevice")
-    if [ -z "$label" ] || [ -z "$uuid" ]; then
-        die "Overlay creation failed: failed to look up root device label and UUID"
+    local line
+    line=$(blkid "$rootDevice")
+
+    label="${line#* LABEL=\"}"
+    if [ "$label" = "$line" ]; then
+        die "Overlay creation failed: failed to look up root device label"
     fi
+    label="${label%%\"*}"
+    uuid="${line#* UUID=\"}"
+    if [ "$uuid" = "$line" ]; then
+        die "Overlay creation failed: failed to look up root device UUID"
+    fi
+    uuid="${uuid%%\"*}"
 }
 
 createPartition() {

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -137,24 +137,30 @@ else
     fi
 fi
 
+dev_to_overlay_pathname() {
+    local device="$1"
+    local label uuid
+
+    label=$(blkid -s LABEL -o value "$device") || label=""
+    uuid=$(blkid -s UUID -o value "$device") || uuid=""
+    echo "overlay-$label-$uuid"
+}
+
 # overlay setup helper function
 do_live_overlay() {
     # create a sparse file for the overlay
     # overlay: if non-ram overlay searching is desired, do it,
     #              otherwise, create traditional overlay in ram
 
-    l=$(blkid -s LABEL -o value "$livedev") || l=""
-    u=$(blkid -s UUID -o value "$livedev") || u=""
-
     if [ -z "$overlay" ]; then
-        pathspec="/${live_dir}/overlay-$l-$u"
+        pathspec="/${live_dir}/$(dev_to_overlay_pathname "$livedev")"
     elif strstr "$overlay" ":"; then
         # pathspec specified, extract
         pathspec=${overlay##*:}
     fi
 
     if [ -z "$pathspec" ] || [ "$pathspec" = "auto" ]; then
-        pathspec="/${live_dir}/overlay-$l-$u"
+        pathspec="/${live_dir}/$(dev_to_overlay_pathname "$livedev")"
     elif ! str_starts "$pathspec" "/"; then
         pathspec=/"${pathspec}"
     fi

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -139,10 +139,24 @@ fi
 
 dev_to_overlay_pathname() {
     local device="$1"
-    local label uuid
+    local label line uuid
 
-    label=$(blkid -s LABEL -o value "$device") || label=""
-    uuid=$(blkid -s UUID -o value "$device") || uuid=""
+    line=$(blkid "$device")
+
+    label="${line#* LABEL=\"}"
+    if [ "$label" != "$line" ]; then
+        label="${label%%\"*}"
+    else
+        label=""
+    fi
+
+    uuid="${line#* UUID=\"}"
+    if [ "$uuid" != "$line" ]; then
+        uuid="${uuid%%\"*}"
+    else
+        uuid=""
+    fi
+
     echo "overlay-$label-$uuid"
 }
 


### PR DESCRIPTION
The busybox `blkid` applet does not support the options `-o` and `-s`.

Strip those options from the `blkid` calls and parse the output in shell to get to the wanted values.

Part of: https://github.com/dracut-ng/dracut/issues/2437

There is also the upstream request: https://github.com/vda-linux/busybox_mirror/issues/33

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
