### PR TITLE
fix(base): support blkid applet from busybox

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -652,49 +652,6 @@ copytree() {
     )
 }
 
-# Evaluates command for UUIDs either given as arguments for this function or all
-# listed in /dev/disk/by-uuid.  UUIDs doesn't have to be fully specified.  If
-# beginning is given it is expanded to all matching UUIDs.  To pass full UUID to
-# your command use '$___' as a place holder.  Remember to escape '$'!
-#
-# foreach_uuid_until [ -p prefix ] command UUIDs
-#
-# prefix - string to put just before $___
-# command - command to be evaluated
-# UUIDs - list of UUIDs separated by space
-#
-# The function returns after *first successful evaluation* of the given command
-# with status 0.  If evaluation fails for every UUID function returns with
-# status 1.
-#
-# Example:
-# foreach_uuid_until "mount -U \$___ /mnt; echo OK; umount /mnt" \
-#       "01234 f512 a235567f-12a3-c123-a1b1-01234567abcb"
-foreach_uuid_until() (
-    cd /dev/disk/by-uuid || return 1
-
-    [ "$1" = -p ] && local prefix="$2" && shift 2
-    local cmd="$1"
-    shift
-    local uuids_list="$*"
-    local uuid
-    local full_uuid
-    local ___
-
-    [ -n "${cmd}" ] || return 1
-
-    for uuid in ${uuids_list:-*}; do
-        for full_uuid in "${uuid}"*; do
-            [ -e "${full_uuid}" ] || continue
-            # shellcheck disable=SC2034
-            ___="${prefix}${full_uuid}"
-            eval "${cmd}" && return 0
-        done
-    done
-
-    return 1
-)
-
 # Get kernel name for given device.  Device may be the name too (then the same
 # is returned), a symlink (full path), UUID (prefixed with "UUID=") or label
 # (prefixed with "LABEL=").  If just a beginning of the UUID is specified or

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -711,20 +711,35 @@ foreach_uuid_until() (
 #   /dev/sdf3
 devnames() {
     local dev="$1"
-    local d
-    local names
+    local d line names target
 
     case "$dev" in
         UUID=*)
-            # shellcheck disable=SC2016
-            dev="$(foreach_uuid_until '! blkid -U $___' "${dev#UUID=}")" \
-                && return 255
-            [ -z "$dev" ] && return 255
+            target="${dev#UUID=}"
+            dev="$(blkid | while read -r line; do
+                case "$line" in
+                    *" UUID=\"${target}"*\")
+                        echo "${line%%:*}"
+                        ;;
+                esac
+            done)"
             ;;
-        LABEL=*) dev="$(blkid -L "${dev#LABEL=}")" || return 255 ;;
+        LABEL=*)
+            target="${dev#LABEL=}"
+            dev="$(blkid | while read -r line; do
+                case "$line" in
+                    *" LABEL=\"${target}\""*)
+                        echo "${line%%:*}"
+                        break
+                        ;;
+                esac
+            done)"
+            ;;
         /dev/?*) ;;
         *) return 255 ;;
     esac
+
+    [ -n "$dev" ] || return 255
 
     for d in $dev; do
         names="$names


### PR DESCRIPTION
The busybox `blkid` applet does not support the options `-L` and `-U`.

Strip those options from the `blkid` calls and parse the output in shell to get to the wanted values. Drop using `foreach_uuid_until` in this process, because this function uses `eval`.

Part of: https://github.com/dracut-ng/dracut/issues/2437

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
