### PR TITLE
fix(drm): add leds-qcom-lpg to aarch64 specific modules needed by drm

### DIFF
--- a/modules.d/45drm/module-setup.sh
+++ b/modules.d/45drm/module-setup.sh
@@ -12,6 +12,7 @@ installkernel() {
     if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 ]]; then
         # arm/aarch64 specific modules needed by drm
         hostonly=$(optional_hostonly) instmods \
+            leds-qcom-lpg \
             "=drivers/gpu/drm/i2c" \
             "=drivers/gpu/drm/panel" \
             "=drivers/gpu/drm/bridge" \


### PR DESCRIPTION
leds-qcom-lpg is not only a LED class driver but it can also be a pwm class driver and sometimes its pwm function is used for panel backlight control in which case it is needed for drm/kms to work.

Since leds-qcom-lpg lives under drivers/leds/rgb/ it is not automatically picked-up by the existing 'instmods "=drivers/pwm"', add it explicitly to the instmods argument to get it included into the initramfs.

This follows the pattern of how the amdkfd and hyperv_fb special cases are already handled.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
