### PR TITLE
fix: support busybox built with CONFIG_FEATURE_PREFER_APPLETS

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -52,16 +52,19 @@ install() {
         if [[ ${_path##*/} == mount ]]; then
             # The busybox mount applet does not resolve "auto" to the actual filesystem.
             # See https://github.com/vda-linux/busybox_mirror/issues/34
+            # Note: When dropping this workaround, replace /bin/mount by mount
             continue
         fi
         if [[ ${_path##*/} == nbd-client ]]; then
             # The busybox nbd-client applet does not support the option -check.
             # See https://github.com/vda-linux/busybox_mirror/issues/35
+            # Note: When dropping this workaround, replace /usr/sbin/nbd-client by nbd-client
             continue
         fi
         if [[ ${_path##*/} == sulogin ]]; then
             # The busybox sulogin applet does not support the option -e.
             # See https://github.com/vda-linux/busybox_mirror/issues/36
+            # Note: When dropping this workaround, replace /sbin/sulogin by sulogin
             continue
         fi
 

--- a/modules.d/11fips/fips.sh
+++ b/modules.d/11fips/fips.sh
@@ -68,7 +68,7 @@ mount_boot() {
 
         mkdir -p /boot
         fips_info "Mounting $boot as /boot"
-        mount -oro "$boot" /boot || return 1
+        /bin/mount -oro "$boot" /boot || return 1
         FIPS_MOUNTED_BOOT=1
     elif ! ismounted /boot && [ -d "$NEWROOT/boot" ]; then
         # shellcheck disable=SC2114

--- a/modules.d/70crypt-lib/crypt-lib.sh
+++ b/modules.d/70crypt-lib/crypt-lib.sh
@@ -173,7 +173,7 @@ test_dev() {
     [ -n "$dev" ] && [ -n "$*" ] || return 1
     [ -d "$mount_point" ] || die 'Mount point does not exist!'
 
-    if mount -r "$dev" "$mount_point" > /dev/null 2>&1; then
+    if /bin/mount -r "$dev" "$mount_point" > /dev/null 2>&1; then
         test "$test_op" "${mount_point}/${f}"
         ret=$?
         umount "$mount_point"
@@ -264,7 +264,7 @@ readkey() {
 
         if [ ! -d "$mntp" ]; then
             mkdir -p "$mntp"
-            mount -r "$keydev" "$mntp" || die 'Mounting rem. dev. failed!'
+            /bin/mount -r "$keydev" "$mntp" || die 'Mounting rem. dev. failed!'
         fi
     fi
 

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -169,10 +169,10 @@ do_live_overlay() {
             mount -o remount,rw "$devspec"
             mount --bind "$devmnt" /run/initramfs/overlayfs
         else
-            mount -n -t auto "$devspec" /run/initramfs/overlayfs || :
+            /bin/mount -n -t auto "$devspec" /run/initramfs/overlayfs || :
         fi
         if [ -f "/run/initramfs/overlayfs$pathspec" ] && [ -w "/run/initramfs/overlayfs$pathspec" ]; then
-            OVERLAY_LOOPDEV=$(losetup -f --show ${readonly_overlay:+-r} "/run/initramfs/overlayfs$pathspec")
+            OVERLAY_LOOPDEV=$(/sbin/losetup -f --show ${readonly_overlay:+-r} "/run/initramfs/overlayfs$pathspec")
             over=$OVERLAY_LOOPDEV
             umount -l /run/initramfs/overlayfs || :
             oltype=$(det_img_fs "$OVERLAY_LOOPDEV")
@@ -271,10 +271,10 @@ do_live_overlay() {
         else
             dd if=/dev/null of=/overlay bs=1024 count=1 seek=$((overlay_size * 1024)) 2> /dev/null
             if [ -n "$setup" ] && [ -n "$readonly_overlay" ]; then
-                RO_OVERLAY_LOOPDEV=$(losetup -f --show /overlay)
+                RO_OVERLAY_LOOPDEV=$(/sbin/losetup -f --show /overlay)
                 over=$RO_OVERLAY_LOOPDEV
             else
-                OVERLAY_LOOPDEV=$(losetup -f --show /overlay)
+                OVERLAY_LOOPDEV=$(/sbin/losetup -f --show /overlay)
                 over=$OVERLAY_LOOPDEV
             fi
         fi
@@ -303,8 +303,8 @@ do_live_overlay() {
         dd if=/dev/null of=/run/initramfs/thin-overlay/meta bs=1b count=1 seek=$((thin_meta_sz)) 2> /dev/null
         dd if=/dev/null of=/run/initramfs/thin-overlay/data bs=1b count=1 seek=$((thin_data_sz)) 2> /dev/null
 
-        THIN_META_LOOPDEV=$(losetup --show -f /run/initramfs/thin-overlay/meta)
-        THIN_DATA_LOOPDEV=$(losetup --show -f /run/initramfs/thin-overlay/data)
+        THIN_META_LOOPDEV=$(/sbin/losetup --show -f /run/initramfs/thin-overlay/meta)
+        THIN_DATA_LOOPDEV=$(/sbin/losetup --show -f /run/initramfs/thin-overlay/data)
 
         echo 0 $thin_data_sz thin-pool "$THIN_META_LOOPDEV" "$THIN_DATA_LOOPDEV" 1024 1024 | dmsetup create live-overlay-pool
         dmsetup message /dev/mapper/live-overlay-pool 0 "create_thin 0"
@@ -400,7 +400,7 @@ if [ -n "$FSIMG" ]; then
     if [ "$FSIMG" = "$SQUASHED" ]; then
         BASE_LOOPDEV=$SQUASHED_LOOPDEV
     else
-        BASE_LOOPDEV=$(losetup -f --show ${readonly_base:+-r} "$FSIMG")
+        BASE_LOOPDEV=$(/sbin/losetup -f --show ${readonly_base:+-r} "$FSIMG")
         sz=$(blockdev --getsz "$BASE_LOOPDEV")
     fi
     if [ "$setup" = rw ]; then
@@ -438,7 +438,7 @@ if [ -n "$overlayfs" ]; then
 else
     if [ -z "${DRACUT_SYSTEMD-}" ]; then
         [ -n "$ROOTFLAGS" ] && ROOTFLAGS="-o $ROOTFLAGS"
-        printf 'mount %s /dev/mapper/live-rw %s\n' "$ROOTFLAGS" "$NEWROOT" > "$hookdir"/mount/01-$$-live.sh
+        printf '/bin/mount %s /dev/mapper/live-rw %s\n' "$ROOTFLAGS" "$NEWROOT" > "$hookdir"/mount/01-$$-live.sh
     fi
 fi
 [ -e "$SQUASHED" ] && umount -l /run/initramfs/squashfs

--- a/modules.d/70dmsquash-live/iso-scan.sh
+++ b/modules.d/70dmsquash-live/iso-scan.sh
@@ -19,7 +19,7 @@ do_iso_scan() {
         _name=$(dev_unit_name "$dev")
         [ -e /tmp/isoscan-"${_name}" ] && continue
         : > /tmp/isoscan-"${_name}"
-        mount -t auto -o ro "$dev" "/run/initramfs/isoscan" || continue
+        /bin/mount -t auto -o ro "$dev" "/run/initramfs/isoscan" || continue
         if [ -f "/run/initramfs/isoscan/$isofile" ]; then
             losetup -f "/run/initramfs/isoscan/$isofile"
             udevadm trigger --action=add > /dev/null 2>&1

--- a/modules.d/70img-lib/img-lib.sh
+++ b/modules.d/70img-lib/img-lib.sh
@@ -27,7 +27,7 @@ det_archive() {
 # determine filesystem type for a filesystem image
 det_fs_img() {
     local dev
-    dev=$(losetup --find --show "$1") rv=""
+    dev=$(/sbin/losetup --find --show "$1") rv=""
     det_fs "$dev"
     rv=$?
     losetup -d "$dev"
@@ -64,7 +64,7 @@ unpack_fs() {
     local img="$1" outdir="$2"
     local mnt
     mnt="$(mkuniqdir /tmp unpack_fs.)"
-    mount -o loop "$img" "$mnt" || {
+    /bin/mount -o loop "$img" "$mnt" || {
         rmdir "$mnt"
         return 1
     }

--- a/modules.d/70overlayfs/prepare-overlayfs.sh
+++ b/modules.d/70overlayfs/prepare-overlayfs.sh
@@ -65,7 +65,7 @@ if [ "$overlay_mode" = "device" ] && [ -n "$overlay_device" ]; then
 
     mkdir -m 0755 -p /run/overlayfs-backing
 
-    if mount "$overlay_device" /run/overlayfs-backing; then
+    if /bin/mount "$overlay_device" /run/overlayfs-backing; then
         info "Successfully mounted persistent overlay on $overlay_device"
 
         mkdir -m 0755 -p /run/overlayfs-backing/overlay

--- a/modules.d/71overlayfs-crypt/prepare-overlayfs-crypt.sh
+++ b/modules.d/71overlayfs-crypt/prepare-overlayfs-crypt.sh
@@ -32,7 +32,7 @@ fi
 overlay_device="$_RET_DEVICE"
 mkdir -m 0755 -p /run/overlayfs-backing
 
-if ! mount "$overlay_device" /run/overlayfs-backing; then
+if ! /bin/mount "$overlay_device" /run/overlayfs-backing; then
     warn "Failed to mount encrypted overlay $overlay_device, falling back to tmpfs"
     _overlayfs_crypt_fallback_tmpfs
     return 0

--- a/modules.d/73crypt-loop/crypt-loop-lib.sh
+++ b/modules.d/73crypt-loop/crypt-loop-lib.sh
@@ -22,7 +22,7 @@ loop_decrypt() {
     if [ ! -b "$key" ]; then
         local loopdev
         local opts
-        loopdev=$(losetup -f "${mntp}/${keypath}" --show)
+        loopdev=$(/sbin/losetup -f "${mntp}/${keypath}" --show)
         opts="-d - luksOpen $loopdev ${key##*/}"
 
         ask_for_password \

--- a/modules.d/73zipl/install_zipl_cmdline.sh
+++ b/modules.d/73zipl/install_zipl_cmdline.sh
@@ -11,7 +11,7 @@ fi
 
 [ -d ${MNT} ] || mkdir -p ${MNT}
 
-if ! mount -o ro "${DEV}" ${MNT}; then
+if ! /bin/mount -o ro "${DEV}" ${MNT}; then
     echo "Failed to mount ${MNT}"
     : > /tmp/install.zipl.cmdline-done
     exit 1

--- a/modules.d/74iscsi/mount-lun.sh
+++ b/modules.d/74iscsi/mount-lun.sh
@@ -5,7 +5,7 @@ fi
 NEWROOT=${NEWROOT:-/sysroot}
 
 for disk in /dev/disk/by-path/*-iscsi-*-"$iscsi_lun"; do
-    if mount -t "${fstype:-auto}" -o "$rflags" "$disk" "$NEWROOT"; then
+    if /bin/mount -t "${fstype:-auto}" -o "$rflags" "$disk" "$NEWROOT"; then
         if [ ! -d "$NEWROOT"/proc ]; then
             umount "$disk"
             continue

--- a/modules.d/74nbd/nbdroot.sh
+++ b/modules.d/74nbd/nbdroot.sh
@@ -128,9 +128,9 @@ if ! [ "$nbdport" -gt 0 ] 2> /dev/null; then
     nbdport="-name $nbdport"
 fi
 
-if ! nbd-client -check /dev/nbd0 > /dev/null; then
+if ! /usr/sbin/nbd-client -check /dev/nbd0 > /dev/null; then
     # shellcheck disable=SC2086
-    nbd-client -p -systemd-mark "$nbdserver" $nbdport /dev/nbd0 $opts || exit 1
+    /usr/sbin/nbd-client -p -systemd-mark "$nbdserver" $nbdport /dev/nbd0 $opts || exit 1
 fi
 
 need_shutdown

--- a/modules.d/74nbd/parse-nbdroot.sh
+++ b/modules.d/74nbd/parse-nbdroot.sh
@@ -61,4 +61,4 @@ if [ -z "$root" ]; then
     # the device is created and waited for in ./nbdroot.sh
 fi
 
-echo 'nbd-client -check /dev/nbd0 > /dev/null 2>&1' > "$hookdir"/initqueue/finished/nbdroot.sh
+echo '/usr/sbin/nbd-client -check /dev/nbd0 > /dev/null 2>&1' > "$hookdir"/initqueue/finished/nbdroot.sh

--- a/modules.d/74rootfs-block-fallback/rootfallback.sh
+++ b/modules.d/74rootfs-block-fallback/rootfallback.sh
@@ -10,7 +10,7 @@ for root in $(getargs rootfallback=); do
         continue
     fi
 
-    if mount "$root" /sysroot; then
+    if /bin/mount "$root" /sysroot; then
         info "Mounted rootfallback $root"
         exit 0
     else

--- a/modules.d/74rootfs-block/mount-root.sh
+++ b/modules.d/74rootfs-block/mount-root.sh
@@ -80,10 +80,10 @@ mount_root() {
 
     if ! ismounted "$NEWROOT"; then
         info "Mounting ${root#block:} with -o ${rflags}"
-        mount "$NEWROOT" 2>&1 | vinfo
+        /bin/mount "$NEWROOT" 2>&1 | vinfo
     elif ! are_lists_eq , "$rflags" "$_rflags_ro" defaults; then
         info "Remounting ${root#block:} with -o ${rflags}"
-        mount -o remount "$NEWROOT" 2>&1 | vinfo
+        /bin/mount -o remount "$NEWROOT" 2>&1 | vinfo
     fi
 }
 

--- a/modules.d/77dracut-systemd/dracut-emergency.sh
+++ b/modules.d/77dracut-systemd/dracut-emergency.sh
@@ -36,7 +36,7 @@ if getargbool 1 rd.shell || getarg rd.break; then
 
     if getargbool 0 SYSTEMD_SULOGIN_FORCE; then
         # allows passwordless logins if root account is locked.
-        exec sulogin -e
+        exec /sbin/sulogin -e
     else
         exec sulogin
     fi

--- a/modules.d/86shutdown/shutdown.sh
+++ b/modules.d/86shutdown/shutdown.sh
@@ -88,7 +88,7 @@ umount_a() {
         fi
     done < /proc/mounts
 
-    losetup -D 2>&7
+    /sbin/losetup -D 2>&7
 
     exec 7>&-
     [ "$_did_umount" = "y" ] && return 0


### PR DESCRIPTION
The busybox Dracut modules skips installing some incompatible applets. This workaround has no effect in case busybox was built with `CONFIG_FEATURE_PREFER_APPLETS`. The Debian/Ubuntu busybox-static package is built with that option. This causes the NBD test to fail:

```
$ TEST_CONTAINER_COMMAND="apt update && apt install --yes busybox-static" test/test.sh ubuntu:devel 72
[...]
[    1.345256] dracut-initqueue[634]: nbd-client: unrecognized option '-check'
[    1.346137] dracut-initqueue[634]: BusyBox v1.38.0 (Ubuntu 1:1.38.0-3ubuntu1) multi-call binary.
[    1.346719] dracut-initqueue[634]: Usage: nbd-client { [-b BLKSIZE] [-N NAME] [-t SEC] [-p] HOST [PORT] | -d } BLOCKDEV
[    1.347399] dracut-initqueue[634]: Connect to HOST and provide network block device on BLOCKDEV
[    1.348014] dracut-initqueue[635]: nbd-client: unrecognized option '-systemd-mark'
[    1.348493] dracut-initqueue[635]: BusyBox v1.38.0 (Ubuntu 1:1.38.0-3ubuntu1) multi-call binary.
[    1.349055] dracut-initqueue[635]: Usage: nbd-client { [-b BLKSIZE] [-N NAME] [-t SEC] [-p] HOST [PORT] | -d } BLOCKDEV
[    1.349710] dracut-initqueue[635]: Connect to HOST and provide network block device on BLOCKDEV
```

So use absolute paths for `mount`, `nbd-client`, and `sulogin` where needed. No change for `blkid` is needed, because Dracut supports `blkid` except for some udev rules that already use absolute paths. No change for `mke2fs` is needed, because busybox lacks a `mkfs.ext4` applet. Absolute paths for mount is needed for cases where the type is `auto` or not specified. Some code already determines the type and mounts the relevant kernel module:

```sh
    fstype=$(det_img_fs "$1")
    load_fstype "$fstype"
    mount -r "$1" "$2"
```

This PR depends on those PRs to land first:
* https://github.com/dracut-ng/dracut/pull/2719
* https://github.com/dracut-ng/dracut/pull/2720

Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
