### PR TITLE
fix(nbd): support busybox with CONFIG_FEATURE_PREFER_APPLETS

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -57,6 +57,7 @@ install() {
         if [[ ${_path##*/} == nbd-client ]]; then
             # The busybox nbd-client applet does not support the option -check.
             # See https://github.com/vda-linux/busybox_mirror/issues/35
+            # Note: When dropping this workaround, replace /usr/sbin/nbd-client by nbd-client
             continue
         fi
         if [[ ${_path##*/} == sulogin ]]; then

--- a/modules.d/74nbd/nbdroot.sh
+++ b/modules.d/74nbd/nbdroot.sh
@@ -128,9 +128,9 @@ if ! [ "$nbdport" -gt 0 ] 2> /dev/null; then
     nbdport="-name $nbdport"
 fi
 
-if ! nbd-client -check /dev/nbd0 > /dev/null; then
+if ! /usr/sbin/nbd-client -check /dev/nbd0 > /dev/null; then
     # shellcheck disable=SC2086
-    nbd-client -p -systemd-mark "$nbdserver" $nbdport /dev/nbd0 $opts || exit 1
+    /usr/sbin/nbd-client -p -systemd-mark "$nbdserver" $nbdport /dev/nbd0 $opts || exit 1
 fi
 
 need_shutdown

--- a/modules.d/74nbd/parse-nbdroot.sh
+++ b/modules.d/74nbd/parse-nbdroot.sh
@@ -61,4 +61,4 @@ if [ -z "$root" ]; then
     # the device is created and waited for in ./nbdroot.sh
 fi
 
-echo 'nbd-client -check /dev/nbd0 > /dev/null 2>&1' > "$hookdir"/initqueue/finished/nbdroot.sh
+echo '/usr/sbin/nbd-client -check /dev/nbd0 > /dev/null 2>&1' > "$hookdir"/initqueue/finished/nbdroot.sh


### PR DESCRIPTION
The busybox Dracut modules skips installing some incompatible applets. This workaround has no effect in case busybox was built with `CONFIG_FEATURE_PREFER_APPLETS`. The Debian/Ubuntu busybox-static package is built with that option. This causes the NBD test to fail:

```
$ TEST_CONTAINER_COMMAND="apt update && apt install --yes busybox-static" test/test.sh ubuntu:devel 72
[...]
[    1.345256] dracut-initqueue[634]: nbd-client: unrecognized option '-check'
[    1.346137] dracut-initqueue[634]: BusyBox v1.38.0 (Ubuntu 1:1.38.0-3ubuntu1) multi-call binary.
[    1.346719] dracut-initqueue[634]: Usage: nbd-client { [-b BLKSIZE] [-N NAME] [-t SEC] [-p] HOST [PORT] | -d } BLOCKDEV
[    1.347399] dracut-initqueue[634]: Connect to HOST and provide network block device on BLOCKDEV
[    1.348014] dracut-initqueue[635]: nbd-client: unrecognized option '-systemd-mark'
[    1.348493] dracut-initqueue[635]: BusyBox v1.38.0 (Ubuntu 1:1.38.0-3ubuntu1) multi-call binary.
[    1.349055] dracut-initqueue[635]: Usage: nbd-client { [-b BLKSIZE] [-N NAME] [-t SEC] [-p] HOST [PORT] | -d } BLOCKDEV
[    1.349710] dracut-initqueue[635]: Connect to HOST and provide network block device on BLOCKDEV
```

So use absolute paths for `nbd-client` to avoid using the applet when running shell code in busybox shell.

Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
