### PR TITLE
fix(busybox): do not install blkid unconditionally

### DIFF
--- a/modules.d/10busybox/module-setup.sh
+++ b/modules.d/10busybox/module-setup.sh
@@ -34,8 +34,8 @@ install() {
 
     # install busybox symlinks manually
     for _path in ${_busybox_applets}; do
-        if [[ ${_path##*/} == blkid ]] && grep -qr "blkid -o" "${udevdir}/rules.d" 2> /dev/null; then
-            # The busybox blkid applet does not support the option -o.
+        if [[ ${_path##*/} == blkid ]]; then
+            # The busybox blkid applet does not support the options -o and -s.
             # See https://github.com/vda-linux/busybox_mirror/issues/33
             continue
         fi


### PR DESCRIPTION
The busybox `blkid` applet does not support the option `-o` and `-s`, but `blkid` is used with those options in
`modules.d/70dmsquash-live-autooverlay/create-overlay.sh` and `modules.d/70dmsquash-live/dmsquash-live-root.sh`.

So always exclude the `blkid` busybox applet.

Test 46 fails on ubuntu:devel on arm due to including `blkid`: https://github.com/dracut-ng/dracut/actions/runs/33925419195/job/101192756712

Part of: https://github.com/dracut-ng/dracut/issues/2437

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
