### PR TITLE
fix: locate the initramfs on ostree-based systems

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -18,6 +18,7 @@ KERNEL_VERSION="$(uname -r)"
 find_initrd_for_kernel_version() {
     local kernel_version="$1"
     local base_path f initrd machine_id
+    local arg deploy entries entry match opt
 
     if [ -d /efi/Default ] || [ -d /boot/Default ] || [ -d /boot/efi/Default ]; then
         machine_id="Default"
@@ -31,6 +32,61 @@ find_initrd_for_kernel_version() {
     if [ -n "$machine_id" ]; then
         for base_path in /efi /boot /boot/efi; do
             initrd="${base_path}/${machine_id}/${kernel_version}/initrd"
+            if [ -f "$initrd" ]; then
+                echo "$initrd"
+                return
+            fi
+        done
+    fi
+
+    # ostree-based distributions (Silverblue, RHEL for Edge, FCOS) keep
+    # per-deployment images under /boot/ostree/<stateroot>-<bootcsum>/
+    if [ -d /boot/ostree ]; then
+        # Prefer the deployment the running kernel booted with, resolved
+        # through its BLS loader entry: the ostree= kernel argument carries
+        # the deployment path, and the matching entry's "initrd" line then
+        # names the exact image.  The filename must match the kernel
+        # version so spec-valid entries that load a microcode image first
+        # cannot mislead the selection.
+        deploy=""
+        set -f
+        for arg in $(tr -d '\r' < /proc/cmdline); do
+            case $arg in
+                ostree=*) deploy=${arg#ostree=} ;;
+            esac
+        done
+        set +f
+        if [ -n "$deploy" ]; then
+            for entries in /efi/loader/entries /boot/loader*/entries /boot/efi/loader/entries; do
+                for entry in "$entries"/*.conf; do
+                    [ -f "$entry" ] || continue
+                    match=n
+                    for opt in $(sed -n 's/^options[[:space:]]\{1,\}//p' "$entry" | tr -d '\r'); do
+                        if [ "$opt" = "ostree=$deploy" ]; then
+                            match=y
+                            break
+                        fi
+                    done
+                    [ "$match" = y ] || continue
+                    for initrd in $(sed -n 's/^initrd[[:space:]]\{1,\}//p' "$entry" | tr -d '\r'); do
+                        case $initrd in
+                            *initramfs-"${kernel_version}".img) ;;
+                            *) continue ;;
+                        esac
+                        initrd=${initrd#/}
+                        # OSTree sysroot.bootprefix entries are already
+                        # boot-root-based (/boot/ostree/...); only prepend
+                        # /boot for truly initrd-root-relative paths.
+                        initrd=${initrd#boot/}
+                        if [ -f "/boot/$initrd" ]; then
+                            echo "/boot/$initrd"
+                            return
+                        fi
+                    done
+                done
+            done
+        fi
+        for initrd in /boot/ostree/*/initramfs-"${kernel_version}".img; do
             if [ -f "$initrd" ]; then
                 echo "$initrd"
                 return

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -131,7 +131,7 @@ fi
 
 find_initrd_for_kernel_version() {
     local kernel_version="$1"
-    local base_path files initrd machine_id
+    local arg base_path deploy entries entry files initrd machine_id match opt
 
     if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
         machine_id="Default"
@@ -146,6 +146,56 @@ find_initrd_for_kernel_version() {
         for base_path in /efi /boot /boot/efi; do
             initrd="${base_path}/${machine_id}/${kernel_version}/initrd"
             if [ -f "$initrd" ]; then
+                echo "$initrd"
+                return
+            fi
+        done
+    fi
+
+    # ostree-based distributions (Silverblue, RHEL for Edge, FCOS) keep
+    # per-deployment images under /boot/ostree/<stateroot>-<bootcsum>/
+    if [ -d /boot/ostree ]; then
+        # Prefer the deployment the running kernel booted with, resolved
+        # through its BLS loader entry: the ostree= kernel argument carries
+        # the deployment path, and the matching entry's "initrd" line then
+        # names the exact image.  The filename must match the requested
+        # kernel version, so spec-valid entries that load a microcode
+        # image first cannot mislead the selection and -k <other-kver>
+        # cannot return the running kernel's image.
+        deploy=""
+        for arg in $(tr -d '\r' < /proc/cmdline); do
+            case "$arg" in
+                ostree=*) deploy=${arg#ostree=} ;;
+            esac
+        done
+        if [[ -n $deploy ]]; then
+            for entries in /efi/loader/entries /boot/loader*/entries /boot/efi/loader/entries; do
+                for entry in "$entries"/*.conf; do
+                    [[ -f $entry ]] || continue
+                    match=n
+                    for opt in $(sed -n 's/^options[[:space:]]\{1,\}//p' "$entry" | tr -d '\r'); do
+                        if [[ $opt == "ostree=$deploy" ]]; then
+                            match=y
+                            break
+                        fi
+                    done
+                    [[ $match == y ]] || continue
+                    for initrd in $(sed -n 's/^initrd[[:space:]]\{1,\}//p' "$entry" | tr -d '\r'); do
+                        case $initrd in
+                            *initramfs-"${kernel_version}".img) ;;
+                            *) continue ;;
+                        esac
+                        initrd=${initrd#/}
+                        if [[ -f /boot/$initrd ]]; then
+                            echo "/boot/$initrd"
+                            return
+                        fi
+                    done
+                done
+            done
+        fi
+        for initrd in /boot/ostree/*/initramfs-"${kernel_version}".img; do
+            if [[ -f $initrd ]]; then
                 echo "$initrd"
                 return
             fi

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -186,6 +186,10 @@ find_initrd_for_kernel_version() {
                             *) continue ;;
                         esac
                         initrd=${initrd#/}
+                        # OSTree sysroot.bootprefix entries are already
+                        # boot-root-based (/boot/ostree/...); only prepend
+                        # /boot for truly initrd-root-relative paths.
+                        initrd=${initrd#boot/}
                         if [[ -f /boot/$initrd ]]; then
                             echo "/boot/$initrd"
                             return


### PR DESCRIPTION
## Problem

`find_initrd_for_kernel_version()` (in `dracut-initramfs-restore.sh`, and mirrored in `lsinitrd.sh`) only probes `<machine-id>/<kver>/initrd` under `/efi` `/boot` `/boot/efi`, then `/lib/modules`, then `/boot/initramfs-<kver>.img`, with a loose `/boot/initr*<kver>*` glob as last resort.

None of these matches the ostree layout, where per-deployment images live at `/boot/ostree/<stateroot>-<bootcsum>/initramfs-<kver>.img`. As a result `dracut-initramfs-restore` prints "No initramfs image found to restore!" during `dracut-shutdown.service` on Silverblue, RHEL for Edge, FCOS, etc. (GH #514).

## Fix

Add an ostree lookup arm to both scripts. It pins the running deployment by exact token match of the `ostree=` kernel argument against BLS entries' `options` line, takes the entry's `initrd` line whose filename matches `initramfs-<kver>.img` (so spec-valid microcode-first multi-initrd entries cannot hijack the selection and `lsinitrd -k <other-kver>` never returns the wrong image), probes loader entries under `/efi`, `/boot` and `/boot/efi`, and falls back to matching `/boot/ostree/*/initramfs-<kver>.img` when the deployment cannot be pinned down.

Non-ostree layouts keep the previous code path untouched (`[ -d /boot/ostree ]` gate).

## Validation

15-case mount-namespace simulation matrix (all passing), covering: exact-deployment pick under sh and bash, RHEL for Edge shape, classic RHEL layout unaffected, machine-id priority intact, relative-BLS fallback, unknown-kver empty result, missing `ostree=` karg, stale `ostree=` on a non-ostree root, microcode-first entries, `lsinitrd -k <rollback kver>` selection, CRLF line endings, ESP mounted at `/boot/efi`. `sh -n` / `bash -n` clean; independent review found two defects in the initial version of this patch (microcode hijack, `-k` mismatch), both fixed here.

Relates: https://github.com/dracut-ng/dracut/issues/514