### PR TITLE
refactor(dmsquash-live): use newline variable for error message

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -236,18 +236,9 @@ do_live_overlay() {
             if [ -n "${DRACUT_SYSTEMD-}" ]; then
                 if type plymouth > /dev/null 2>&1 && plymouth --ping; then
                     if getargbool 0 rhgb || getargbool 0 splash; then
-                        m='>>>
->>>
->>>
-
-
-'"$m"
-                        m="${m%n.*}"'n.
-
-
-<<<
-<<<
-<<<'
+                        local n='
+'
+                        m=">>>${n}>>>${n}>>>${n}${n}${n}${m%n.*}n.${n}${n}${n}<<<${n}<<<${n}<<<"
                         plymouth display-message --text="${m}"
                     else
                         plymouth ask-question --prompt="${m}" --command=true


### PR DESCRIPTION
Increase the readability of the error message construction by defining a variable `n` that just contains a newline character.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
