### PR TITLE
fix(busybox): busybox blkid, losetup are not compatible with dracut

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -45,11 +45,12 @@ RUN \
 
 # busybox container
 # replace GNU coreutils, util-linux, kmod binaries with busybox binaries
-# workaround for busybox blkid compatibility, see https://github.com/dracut-ng/dracut/issues/2512
+# blkid compatibility, see https://github.com/vda-linux/busybox_mirror/issues/33
+# losetup compatibility, see https://github.com/vda-linux/busybox_mirror/issues/37
 RUN \
 if [ "$OPTION" == "busybox" ] ; then \
   mkdir /busybox && cd /busybox && /bin/busybox --install -s /busybox ;\
-  rm -f /busybox/blkid ;\
+  rm -f /busybox/blkid /busybox/losetup ;\
   cp -a /busybox/* /bin/ ;\
   cp -a /busybox/* /sbin/ ;\
   cp -a /busybox/* /usr/bin/ ;\

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -49,10 +49,10 @@ RUN \
 RUN \
 if [ "$OPTION" == "busybox" ] ; then \
   mkdir /busybox && cd /busybox && /bin/busybox --install -s /busybox ;\
+  rm -f /busybox/blkid ;\
   cp -a /busybox/* /bin/ ;\
   cp -a /busybox/* /sbin/ ;\
   cp -a /busybox/* /usr/bin/ ;\
   cp -a /busybox/* /usr/sbin/ ;\
   rm -f /bin/kmod ;\
-  apk fix --reinstall blkid ;\
 fi


### PR DESCRIPTION
Remove busybox version of blkid and losetup.

Fixes 864029e.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
