### PR TITLE
Two follow-ups for --prefer

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2575,7 +2575,7 @@ done
 
 export initdir dracutbasedir \
     dracutmodules force_add_dracutmodules add_dracutmodules omit_dracutmodules \
-    mods_to_load \
+    prefer_dracutmodules mods_to_load \
     fw_dir drivers_dir debug no_kernel kernel_only \
     omit_drivers mdadmconf lvmconf root_devs \
     use_fstab fstab_lines libdirs fscks nofscks ro_mnt \

--- a/modules.d/70bluetooth/module-setup.sh
+++ b/modules.d/70bluetooth/module-setup.sh
@@ -14,7 +14,7 @@ check() {
         #  * Keyboard/pointing (0xC0)
         # and if Appearance is set to the value defined for keyboard (0x03C1)
         [ -d "/sys/class/bluetooth" ] && grep -qsiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info \
-            && [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules " != *\ bluetooth\ * ]] \
+            && [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules $prefer_dracutmodules " != *\ bluetooth\ * ]] \
             && dwarn "If you need to use bluetooth, please include it explicitly."
     fi
 


### PR DESCRIPTION
Propagate `prefer_dracutmodules` to modules: some internal (e.g. `bluetooth`) and external (e.g. [openSUSE `kdump`](https://github.com/openSUSE/kdump/blob/6e399fc783871b2087b1c0b59a67051b602c02cf/dracut/module-setup.sh#L8)) dracut modules perform certain checks based on the other `*dracutmodules` variables.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
