### PR TITLE
test(BUSYBOX): check built with CONFIG_FEATURE_TR_CLASSES

### DIFF
--- a/test/TEST-15-BUSYBOX/test.sh
+++ b/test/TEST-15-BUSYBOX/test.sh
@@ -40,11 +40,26 @@ check_applets_from_busybox() {
     return "$ret"
 }
 
+check_busybox_feature_tr_classes() {
+    local lowercase
+    lowercase=$(echo DRACUT | busybox tr '[:upper:]' '[:lower:]')
+    if [ "$lowercase" != "dracut" ]; then
+        echo "Error: busybox was built without CONFIG_FEATURE_TR_CLASSES" >&2
+        return 1
+    fi
+}
+
+check_busybox_features() {
+    check_busybox_feature_tr_classes
+}
+
 test_run() {
     if [[ ${V-} -ge 2 ]]; then
         set -x
     fi
     local ret=0
+
+    check_busybox_features
 
     # Test override the list of applets
     DRACUT_MODULE_BUSYBOX_LINKS="$(cat "${TESTDIR}/busybox.links")" \


### PR DESCRIPTION
Dracut uses code like `tr '[:upper:]' '[:lower:]'` that require the busybox feature `CONFIG_FEATURE_TR_CLASSES`.

Instead of documenting this requirement somewhere, add a test case for it.

See https://github.com/dracut-ng/dracut/issues/2687

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
