### PR TITLE
feat(cpio): use a safer, more realistic example

### DIFF
--- a/src/dracut-cpio/src/main.rs
+++ b/src/dracut-cpio/src/main.rs
@@ -618,7 +618,7 @@ fn archive_loop<R: BufRead, W: Seek + Write>(
 
 fn params_usage(params: &[Argument]) {
     argument::print_help("dracut-cpio", "OUTPUT", params);
-    println!("\nExample: find fs-tree/ | dracut-cpio archive.cpio\n");
+    println!("\nExample: cd fs-tree && find . -print0 | dracut-cpio -0 ../archive.cpio\n");
 }
 
 fn params_process(props: &mut ArchiveProperties) -> argument::Result<PathBuf> {


### PR DESCRIPTION
The dracut-cpio example would create a cpio with all files in a directory named `fs-tree`. Normally users would change the current directory to `fs-tree` and then call `dracut-cpio` from there. Also use null delimiters in the example to make it safer.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
