### PR TITLE
fix(functions): do not try to install rules from $dracutbasedir/rules.d

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1302,6 +1302,7 @@ inst_rules() {
     for _rule in "$@"; do
         unset _found
         if [ "${_rule#/}" = "$_rule" ]; then
+            # _rule contains a relative path
             for r in ${hostonly:+"${dracutsysrootdir-}"/etc/udev/rules.d} "${dracutsysrootdir-}${udevdir}/rules.d"; do
                 [[ -e $r/$_rule ]] || continue
                 _found="$r/$_rule"
@@ -1310,17 +1311,14 @@ inst_rules() {
                 _inst_rule_initqueue "$_found"
                 inst_simple "$_found"
             done
-        fi
-        for r in '' "${dracutsysrootdir-}$dracutbasedir/rules.d/"; do
-            # skip rules without an absolute path
-            [[ "${r}$_rule" != /* ]] && continue
-            [[ -f ${r}$_rule ]] || continue
-            _found="${r}$_rule"
+        elif [[ -f $_rule ]]; then
+            # install rules with absolute path, usually from $moddir
+            _found="$_rule"
             _inst_rule_programs "$_found"
             _inst_rule_group_owner "$_found"
             _inst_rule_initqueue "$_found"
             inst_simple "$_found" "$_target/${_found##*/}"
-        done
+        fi
         [[ $_found ]] || ddebug "Skipping udev rule: $_rule"
     done
 }

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -333,7 +333,10 @@ installs an executable/script <src> in the dracut hook <hookdir> with priority
 ==== inst_rules <udevrule> [ <udevrule> ...]
 
 installs one or more udev rules. Non-existent udev rules are reported, but do
-not let dracut fail.
+not let dracut fail. Relative filenames are searched in the usual udev rule
+directories (/usr/lib/udev/rules.d, /etc/udev/rules.d with **--hostonly**; both
+within **--sysroot** if enabled). Use e.g. **inst_rules
+$moddir/99-my-device.rules** to install rule files included in your module.
 
 ==== inst_sysusers <sysuserconf>
 


### PR DESCRIPTION
The rules.d directory was removed from Dracut source with commit 751c4d43ebf62d2c4f23ce18af9530e820048ed2 (in 2009), existing modules install included rule files from `$moddir`.

I found this while working on #2588: In a cross-build using host dracut installing from `$dracutbasedir` doesn't make sense, and in trying to figure out how to fix it I noticed it doesn't may sense any more in general (see rules from modules above).

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
