### PR TITLE
Install dracut-extractinitrd to bindir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,11 @@
 /.project
 /Makefile.inc
 /dracut-cpio
+/dracut-extractinitrd
 /dracut-install
 /dracut-util
 /dracut.conf.d/*.conf
 /dracut.pc
-/extractinitrd
 /src/dracut-cpio/target/
 /test/*/*.html
 /test/*/*.log

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ man7pages = man/dracut.cmdline.7 \
 
 man8pages = man/dracut.8 \
             man/dracut-catimages.8 \
+            man/dracut-extractinitrd.8 \
             man/dracut-install.8 \
             modules.d/77dracut-systemd/dracut-cmdline.service.8 \
             modules.d/77dracut-systemd/dracut-mount.service.8 \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ manpages = $(man1pages) $(man5pages) $(man7pages) $(man8pages)
 
 .PHONY: install clean distclean archive test all check AUTHORS CONTRIBUTORS doc
 
-all: dracut.pc extractinitrd dracut-install dracut-util
+all: dracut.pc dracut-extractinitrd dracut-install dracut-util
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(KMOD_CFLAGS) $(SYSTEMD_CFLAGS) $(if $(SYSTEMD_LIBS),-DHAVE_SYSTEMD) $< -o $@
@@ -93,7 +93,7 @@ dracut-install: $(DRACUT_INSTALL_OBJECTS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS) $(SYSTEMD_LIBS)
 
 EXTRACTINITRD_OBJECTS = src/extractinitrd/extractinitrd.o
-extractinitrd: $(EXTRACTINITRD_OBJECTS)
+dracut-extractinitrd: $(EXTRACTINITRD_OBJECTS)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 UTIL_OBJECTS = src/util/util.o
@@ -255,8 +255,8 @@ endif
 	if [ -f dracut-install ]; then \
 		install -m 0755 dracut-install $(DESTDIR)$(bindir)/dracut-install; \
 	fi
-	if [ -f extractinitrd ]; then \
-		install -m 0755 extractinitrd $(DESTDIR)$(pkglibdir)/extractinitrd; \
+	if [ -f dracut-extractinitrd ]; then \
+		install -m 0755 dracut-extractinitrd $(DESTDIR)$(pkglibdir)/dracut-extractinitrd; \
 	fi
 	if [ -f dracut-util ]; then \
 		install -m 0755 dracut-util $(DESTDIR)$(pkglibdir)/dracut-util; \
@@ -296,8 +296,8 @@ clean:
 	$(RM) */*/*~
 	$(RM) $(manpages:%=%.xml) dracut.xml
 	$(RM) dracut-*.tar.bz2 dracut-*.tar.xz
+	$(RM) dracut-extractinitrd $(EXTRACTINITRD_OBJECTS)
 	$(RM) dracut-install $(DRACUT_INSTALL_OBJECTS)
-	$(RM) extractinitrd $(EXTRACTINITRD_OBJECTS)
 	$(RM) dracut-util $(UTIL_OBJECTS)
 	$(RM) $(manpages)
 	$(RM) dracut.pc

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ endif
 		install -m 0755 dracut-install $(DESTDIR)$(bindir)/dracut-install; \
 	fi
 	if [ -f dracut-extractinitrd ]; then \
-		install -m 0755 dracut-extractinitrd $(DESTDIR)$(pkglibdir)/dracut-extractinitrd; \
+		install -m 0755 dracut-extractinitrd $(DESTDIR)$(bindir)/dracut-extractinitrd; \
 	fi
 	if [ -f dracut-util ]; then \
 		install -m 0755 dracut-util $(DESTDIR)$(pkglibdir)/dracut-util; \

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -13,8 +13,6 @@ trap 'echo "Received SIGTERM signal, ignoring!" >&2' TERM
 
 KERNEL_VERSION="$(uname -r)"
 
-[ "$dracutbasedir" ] || dracutbasedir=/usr/lib/dracut
-
 find_initrd_for_kernel_version() {
     local kernel_version="$1"
     local base_path f initrd machine_id
@@ -57,7 +55,7 @@ extract_initrd() {
     if command -v 3cpio > /dev/null; then
         3cpio --extract "$initrd"
     else
-        "$dracutbasedir/dracut-extractinitrd" "$initrd"
+        dracut-extractinitrd "$initrd"
     fi
 }
 

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -57,7 +57,7 @@ extract_initrd() {
     if command -v 3cpio > /dev/null; then
         3cpio --extract "$initrd"
     else
-        "$dracutbasedir/extractinitrd" "$initrd"
+        "$dracutbasedir/dracut-extractinitrd" "$initrd"
     fi
 }
 

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -37,8 +37,6 @@ usage() {
     } >&2
 }
 
-[[ $dracutbasedir ]] || dracutbasedir=/usr/lib/dracut
-
 sorted=0
 modules=0
 unset verbose
@@ -111,11 +109,15 @@ if command -v 3cpio > /dev/null; then
     unset threecpio_help_output
 fi
 if ! [[ $EXTRACTOR ]]; then
-    EXTRACTOR="$dracutbasedir/dracut-extractinitrd"
-    if ! [[ -x $EXTRACTOR ]]; then
-        echo "Error: '$EXTRACTOR' not found, cannot continue!" >&2
-        exit 1
+    if [[ -x "${BASH_SOURCE[0]%/*}/dracut-extractinitrd" ]]; then
+        EXTRACTOR="${BASH_SOURCE[0]%/*}/dracut-extractinitrd"
+    else
+        EXTRACTOR="$(command -v dracut-extractinitrd)"
     fi
+fi
+if ! [[ $EXTRACTOR ]]; then
+    echo "Error: Neither 3cpio nor dracut-extractinitrd found, cannot continue!" >&2
+    exit 1
 fi
 
 if ! [[ $KERNEL_VERSION ]]; then

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -111,7 +111,7 @@ if command -v 3cpio > /dev/null; then
     unset threecpio_help_output
 fi
 if ! [[ $EXTRACTOR ]]; then
-    EXTRACTOR="$dracutbasedir/extractinitrd"
+    EXTRACTOR="$dracutbasedir/dracut-extractinitrd"
     if ! [[ -x $EXTRACTOR ]]; then
         echo "Error: '$EXTRACTOR' not found, cannot continue!" >&2
         exit 1

--- a/man/dracut-extractinitrd.8.adoc
+++ b/man/dracut-extractinitrd.8.adoc
@@ -1,0 +1,78 @@
+DRACUT-EXTRACTINITRD(8)
+=======================
+:doctype: manpage
+:man source:   dracut
+:man manual:   dracut
+
+NAME
+----
+dracut-extractinitrd - extracts or lists files from an initrd image
+
+SYNOPSIS
+--------
+**dracut-extractinitrd** [_OPTION_...] _INITRD_ [_PATTERN_...]
+
+DESCRIPTION
+-----------
+The **dracut-extractinitrd** command extracts or lists the content of a given
+initrd image using **cpio** and the appropriate decompressor command.
+
+The initrd image may be a single compressed cpio archive, or the concatenation
+of any number of uncompressed cpio archives optionally followed by a compressed
+cpio archive.
+
+**Note:** This is a dracut internal tool, do not expect a stable interface
+across versions. Use man:lsinitrd[1] instead.
+
+OPTIONS
+-------
+**-l**, **--list**::
+    List the contents of the cpio archives
+
+**-P**, **--parts** _RANGE_::
+    Only operate on specified cpio archive range (e.g. 1, 1-3, 2-, -2)
+
+**--to-stdout**::
+    Extract files to standard output
+
+**-D**, **--directory** _DIR_::
+    Change to directory _DIR_ before extracting
+
+**-v**, **--verbose**::
+    Display verbose messages about extraction
+
+**--debug**::
+    Print debugging information
+
+EXAMPLES
+--------
+
+.List the contents of an initramfs image
+----
+dracut-extractinitrd -l initramfs.img
+----
+
+.Unpack the initramfs image to some-dir/
+----
+dracut-extractinitrd -D some-dir/ initramfs.img
+----
+
+BUGS
+----
+**dracut-extractinitrd** does not support initrd images with more than one
+compressed cpio archive.
+
+AVAILABILITY
+------------
+The dracut-extractinitrd command is part of the dracut package and is available
+from
+link:$$https://github.com/dracut-ng/dracut$$[https://github.com/dracut-ng/dracut]
+
+HISTORY
+-------
+**dracut-extractinitrd** is derived from Debian initramfs-tools'
+**unmkinitramfs**.
+
+SEE ALSO
+--------
+man:lsinitrd[1] man:dracut[8]

--- a/src/extractinitrd/extractinitrd.c
+++ b/src/extractinitrd/extractinitrd.c
@@ -633,7 +633,7 @@ static void usage(FILE *stream)
 {
         fprintf(stream, "\
 \n\
-Usage: extractinitrd [-l|--list] [-P|--parts RANGE] [--to-stdout] [-D|--directory DIR]\n\
+Usage: dracut-extractinitrd [-l|--list] [-P|--parts RANGE] [--to-stdout] [-D|--directory DIR]\n\
                      [-v|--verbose] [--debug] INITRD [PATTERN...]\n\
 \n\
 Options:\n\

--- a/test/TEST-83-EXTRACTINITRD/test.sh
+++ b/test/TEST-83-EXTRACTINITRD/test.sh
@@ -118,7 +118,7 @@ test_full_extraction() {
 
             # Unpack it
             rm -rf "$TESTDIR/output"
-            "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
+            dracut-extractinitrd ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
                 echo >&2 'E: dracut-extractinitrd failed'
                 return 1
             }
@@ -135,7 +135,7 @@ test_part_extraction() {
 
     echo "I: Testing extracting part 1 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
+    dracut-extractinitrd ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
         echo >&2 'E: dracut-extractinitrd failed'
         return 1
     }
@@ -143,7 +143,7 @@ test_part_extraction() {
 
     echo "I: Testing extracting part 2 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
+    dracut-extractinitrd ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
         echo >&2 'E: dracut-extractinitrd failed'
         return 1
     }
@@ -151,7 +151,7 @@ test_part_extraction() {
 
     echo "I: Testing extracting everything except part 1 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
+    dracut-extractinitrd ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
         echo >&2 'E: dracut-extractinitrd failed'
         return 1
     }
@@ -174,17 +174,17 @@ test_extract_to_stdout() {
     construct_initrd_image "2" "2" "$compressor"
 
     echo "I: Testing pattern does not match anything of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --to-stdout \
+    metadata=$(dracut-extractinitrd ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- non-existing)
     assert_equal "$metadata" ''
 
     echo "I: Testing extracting early 1 metadata of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --to-stdout \
+    metadata=$(dracut-extractinitrd ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- kernel/dir0/metadata)
     assert_equal "$metadata" 'early0'
 
     echo "I: Testing extracting two metadata files of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --to-stdout \
+    metadata=$(dracut-extractinitrd ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- kernel/dir1/metadata dir0/metadata)
     assert_equal "$metadata" $'early1\nmain0'
 }
@@ -195,7 +195,7 @@ test_list() {
     construct_initrd_image "1" "2" "$compressor"
 
     echo "I: Testing list full content of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
+    metadata=$(dracut-extractinitrd ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
     assert_equal "$metadata" '.
 kernel
 kernel/dir0
@@ -238,7 +238,7 @@ dir1/file9
 dir1/metadata'
 
     echo "I: Testing list part 2 of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
+    metadata=$(dracut-extractinitrd ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
     assert_equal "$metadata" '.
 dir0
 dir0/file0
@@ -255,6 +255,9 @@ dir0/metadata'
 }
 
 test_run() {
+    if [[ ${V-} -ge 1 ]]; then
+        echo "found dracut-extractinitrd: $(command -v dracut-extractinitrd)"
+    fi
     for compressor in no_compressor gzip bzip2 lzma xz lzop 'lz4 -l' zstd; do
         if ! command -v "${compressor%% *}" &> /dev/null; then
             echo "I: Skip testing with '$compressor' because the command is missing." >&2

--- a/test/TEST-83-EXTRACTINITRD/test.sh
+++ b/test/TEST-83-EXTRACTINITRD/test.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # shellcheck disable=SC2034
-TEST_DESCRIPTION="test extractinitrd"
+TEST_DESCRIPTION="test dracut-extractinitrd"
 
 # Uncomment this to debug failures
 #DEBUG="1"
@@ -118,8 +118,8 @@ test_full_extraction() {
 
             # Unpack it
             rm -rf "$TESTDIR/output"
-            "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
-                echo >&2 'E: extractinitrd failed'
+            "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" "$TESTDIR/initrd.img" || {
+                echo >&2 'E: dracut-extractinitrd failed'
                 return 1
             }
 
@@ -135,24 +135,24 @@ test_part_extraction() {
 
     echo "I: Testing extracting part 1 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
-        echo >&2 'E: extractinitrd failed'
+    "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 1 "$TESTDIR/initrd.img" || {
+        echo >&2 'E: dracut-extractinitrd failed'
         return 1
     }
     verify_extraction 1 0
 
     echo "I: Testing extracting part 2 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
-        echo >&2 'E: extractinitrd failed'
+    "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2 "$TESTDIR/initrd.img" || {
+        echo >&2 'E: dracut-extractinitrd failed'
         return 1
     }
     verify_extraction 0 1
 
     echo "I: Testing extracting everything except part 1 of initrd with $compressor"
     rm -rf "$TESTDIR/output"
-    "${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
-        echo >&2 'E: extractinitrd failed'
+    "${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} -D "$TESTDIR/output" --parts 2- "$TESTDIR/initrd.img" || {
+        echo >&2 'E: dracut-extractinitrd failed'
         return 1
     }
     verify_extraction 0 2
@@ -174,17 +174,17 @@ test_extract_to_stdout() {
     construct_initrd_image "2" "2" "$compressor"
 
     echo "I: Testing pattern does not match anything of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --to-stdout \
+    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- non-existing)
     assert_equal "$metadata" ''
 
     echo "I: Testing extracting early 1 metadata of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --to-stdout \
+    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- kernel/dir0/metadata)
     assert_equal "$metadata" 'early0'
 
     echo "I: Testing extracting two metadata files of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --to-stdout \
+    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --to-stdout \
         "$TESTDIR/initrd.img" -- kernel/dir1/metadata dir0/metadata)
     assert_equal "$metadata" $'early1\nmain0'
 }
@@ -195,7 +195,7 @@ test_list() {
     construct_initrd_image "1" "2" "$compressor"
 
     echo "I: Testing list full content of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
+    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --list "$TESTDIR/initrd.img")
     assert_equal "$metadata" '.
 kernel
 kernel/dir0
@@ -238,7 +238,7 @@ dir1/file9
 dir1/metadata'
 
     echo "I: Testing list part 2 of initrd with $compressor"
-    metadata=$("${PKGLIBDIR}/extractinitrd" ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
+    metadata=$("${PKGLIBDIR}/dracut-extractinitrd" ${DEBUG:+--debug} --list --part 2 "$TESTDIR/initrd.img")
     assert_equal "$metadata" '.
 dir0
 dir0/file0


### PR DESCRIPTION
As discussed in #2588, installing tools used to build an initramfs to `bindir` and expecting them on `PATH` makes it easier to replace them in a cross-build situtation, specifically: if dracut is installed in a cross-sysroot (so running scripts from the sysroot works, but running executables does not). If tools are installed to `PATH` dracut can transparently use tools installed on the host, and users can adjust `PATH` if they want a specific version, or have dracut installed in a non-default location (e.g. a development build instead of installed distro package).

This PR renames `extractinitrd` to `dracut-extractinitrd` (to avoid conflicts with other tools), moves it to `bindir`, and adds a manpage for it (based on its `--help` output).

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
