### PR TITLE
fix(install): do not allow empty --sysrootdir

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1723,6 +1723,10 @@ static int parse_argv(int argc, char *argv[])
                 case 'r':
                         sysrootdir = optarg;
                         sysrootdirlen = strlen(sysrootdir);
+                        if (sysrootdirlen < 1) {
+                                log_error("sysrootdir is set but empty!");
+                                exit(EXIT_FAILURE);
+                        }
                         /* ignore trailing '/' */
                         if (sysrootdir[sysrootdirlen-1] == '/')
                                 sysrootdirlen--;


### PR DESCRIPTION
Not setting it is fine, but setting it with an empty value is a bug.

Split out of #2588.
<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
