### PR TITLE
fix(lsinitrd): write complete error message to stderr

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -113,9 +113,7 @@ fi
 if ! [[ $EXTRACTOR ]]; then
     EXTRACTOR="$dracutbasedir/extractinitrd"
     if ! [[ -x $EXTRACTOR ]]; then
-        echo
         echo "Error: '$EXTRACTOR' not found, cannot continue!" >&2
-        echo
         exit 1
     fi
 fi


### PR DESCRIPTION
In case no extractor is found, an error message is printed on stderr, but the leading and trailing newlines are printed on stdout. This seems like unintentional to me.

This error message was moved around. It is now at the beginning of `lsinitrd`. In this phase no text is printed yet. So the leading and trailing newline are not needed and can be removed.

Fixes: b208aad51c64 ("lsinitrd.sh: make use of the skipcpio utility")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
