### PR TITLE
fix(lsinitrd): write warnings to stderr

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -103,9 +103,9 @@ if command -v 3cpio > /dev/null; then
             EXTRACTOR=3cpio
         fi
     elif command -v cpio > /dev/null; then
-        echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories. Falling back to cpio."
+        echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories. Falling back to cpio." >&2
     else
-        echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories."
+        echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories." >&2
         EXTRACTOR=3cpio
     fi
     unset threecpio_help_output


### PR DESCRIPTION
Warnings should be written to stderr instead of stdout.

Fixes: dbd9f0ee2c62 ("feat: warn in case 3cpio is present but not suitable")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
