### PR TITLE
feat: set dracutbasedir based on install location

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1182,7 +1182,6 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $use_fstab_l ]] && use_fstab=$use_fstab_l
 [[ $mdadmconf_l ]] && mdadmconf=$mdadmconf_l
 [[ $lvmconf_l ]] && lvmconf=$lvmconf_l
-[[ $dracutbasedir ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
 [[ $fw_dir ]] || {
     [[ -e /sys/module/firmware_class/parameters/path ]] \
         && fw_path_para=$(< /sys/module/firmware_class/parameters/path)

--- a/dracut.sh
+++ b/dracut.sh
@@ -997,7 +997,11 @@ export DRACUT_LOG_LEVEL=warning
     debug=yes
 }
 
-[[ ${dracutbasedir-} ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
+[[ ${dracutbasedir-} ]] || dracutbasedir="$(realpath "${BASH_SOURCE[0]%/*}/../lib/dracut")"
+if [[ ! -d $dracutbasedir ]]; then
+    printf "dracut[F]: base directory '%s' does not exist.\n" "$dracutbasedir" >&2
+    exit 1
+fi
 
 export DRACUT_ARCH=${DRACUT_ARCH:-$(uname -m)}
 


### PR DESCRIPTION
`dracutbasedir` is where scripts, modules, and `dracut-util` are loaded from. The default should match the running dracut script, wherever it is installed, assuming the usual `${prefix}/bin/dracut` and `${prefix}/lib/dracut/` locations.

The `--local` option works as before because it overrides `dracutbasedir` before defaults can apply.

Split out of #2588. Together with #2740 and #2745 this should allow running dracut as installed in a cross-sysroot, provided compatible host tools (`dracut-cpio`, `dracut-extractinitrd`, `dracut-install`) are in `PATH`.

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
