### PR TITLE
fix(base): allow loading dracut-lib.sh with set -eu

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -4,7 +4,7 @@ command -v wait_for_dev > /dev/null || . /lib/dracut-dev-lib.sh
 
 export DRACUT_SYSTEMD
 export NEWROOT
-if [ -n "$NEWROOT" ]; then
+if [ -n "${NEWROOT-}" ]; then
     [ -d "$NEWROOT" ] || mkdir -p -m 0755 "$NEWROOT"
 fi
 
@@ -354,7 +354,7 @@ splitsep() {
 
 setdebug() {
     [ -f /usr/lib/initrd-release ] || return 0
-    if [ -z "$RD_DEBUG" ]; then
+    if [ -z "${RD_DEBUG-}" ]; then
         if [ -e /proc/cmdline ]; then
             RD_DEBUG=no
             if getargbool 0 rd.debug; then

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -24,7 +24,7 @@ debug_off() {
 }
 
 debug_on() {
-    [ "$RD_DEBUG" = "yes" ] && set -x
+    [ "$RD_DEBUG" != "yes" ] || set -x
 }
 
 # printf %q implementation for POSIX shell


### PR DESCRIPTION
I was testing a custom module, and noticed the following in an initrd script would fail:

```
set -e
set -u
command -v getarg > /dev/null || . /lib/dracut-lib.sh
```

`NEWROOT` and `RD_DEBUG` were used without ensuring they were set (fixed by providing empty defaults), and the exit status of `[ "$RD_DEBUG" = "yes" ] && set -x` wasn't ignored if debug was disabled.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
