### PR TITLE
fix(fcoe): do not produce an error if there is no configuration in /etc/fcoe

### DIFF
--- a/modules.d/74fcoe/module-setup.sh
+++ b/modules.d/74fcoe/module-setup.sh
@@ -111,7 +111,10 @@ install() {
         _fcoeconf=$(cmdline)
         [[ $_fcoeconf ]] && printf "%s\n" "$_fcoeconf" >> "${initdir}/etc/cmdline.d/20-fcoe.conf"
     fi
-    inst_multiple "/etc/fcoe/cfg-*"
+
+    if [[ $hostonly ]]; then
+        inst_multiple -o "/etc/fcoe/cfg-*"
+    fi
 
     inst "$moddir/fcoe-up.sh" "/sbin/fcoe-up"
     inst "$moddir/fcoe-edd.sh" "/sbin/fcoe-edd"


### PR DESCRIPTION
Upstream allows to configure the package to install only vendor configuration using the `--with-vendordir=` option [1]. E.g., /usr/etc/fcoe in openSUSE:

```
%build
autoreconf -vi
%if 0%{?suse_version} > 1500
%configure  --with-vendordir=%{_distconfdir}
%else
%configure
%endif
make %{?_smp_mflags}
```

This means that the package may decide to avoid creating the /etc/fcoe directory, which produces a non-fatal error while installing the dracut module:

```
[  243s] dracut-install: ERROR: installing '/etc/fcoe/cfg-*'
[  243s] dracut[E]: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.dg998tR/initramfs -a /etc/fcoe/cfg-*
```

Since the only files required for fcoemon are `/etc/fcoe/cfg-<ifname>`, i.e., configuration for specific Ethernet or VLAN interfaces, it should not be necessary to include `/usr/etc/fcoe/cfg-*`; this will only install the ignored cfg-ethx template.

Additionally, wrap the installation of these configuration files in /etc/fcoe within a hostonly section.

[1] https://github.com/openSUSE/fcoe-utils/commit/16f7669b54022477ee0c3bba3390230290440921

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
