### PR TITLE
Allow installing from dracut dir when using sysroot

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1114,11 +1114,11 @@ inst() {
     fi
     [[ -e ${dstdir}/"${2:-$1}" ]] && return 0 # already there
     [[ ${DRACUT_RESOLVE_LAZY-} ]] || _resolve_deps=1
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"
         return $_ret
     fi
 }
@@ -1138,11 +1138,11 @@ inst_binary() {
 inst_script() {
     local _ret _resolve_deps
     [[ ${DRACUT_RESOLVE_LAZY-} ]] || _resolve_deps=1
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${_resolve_deps:+-l} ${DRACUT_FIPS_MODE:+-f} "$@"
         return "$_ret"
     fi
 }
@@ -1161,7 +1161,7 @@ inst_simple() {
     fi
     [[ -e ${dstdir}/"${2:-$1}" ]] && return 0 # already there
     if [[ $1 == /* ]]; then
-        if [[ ! -e ${dracutsysrootdir-}/${1#"${dracutsysrootdir-}"} ]]; then
+        if [[ ! -e ${dracutsysrootdir-}/${1#"${dracutsysrootdir-}"} ]] && [[ ! -e ${dracutbasedir-}/${1#"${dracutbasedir-}"} ]]; then
             dwarn "no source: '$1'!"
             return 1
         fi
@@ -1169,11 +1169,11 @@ inst_simple() {
         dwarn "no source: '$1'!"
         return 1
     fi
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"; then
+    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"; then
         return 0
     else
         _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"
+        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir" ${dracutbasedir:+-B "$dracutbasedir"}} ${dstdir:+-D "$dstdir"} ${loginstall:+-L "$loginstall"} ${_hostonly_install:+-H} "$@"
         return $_ret
     fi
 }

--- a/man/dracut-install.8.adoc
+++ b/man/dracut-install.8.adoc
@@ -10,11 +10,11 @@ dracut-install - install files or kernel modules into initramfs staging director
 
 SYNOPSIS
 --------
-**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_] [_OPTION_]... --all _SOURCE_...
+**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_ [-B _DRACUTDIR_]] [_OPTION_]... --all _SOURCE_...
 
-**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_] [_OPTION_]... _SOURCE_ _DEST_
+**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_ [-B _DRACUTDIR_]] [_OPTION_]... _SOURCE_ _DEST_
 
-**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_] [_OPTION_]... --module _KERNELMODULE_...
+**dracut-install** -D _DESTROOTDIR_ [-r _SYSROOTDIR_ [-B _DRACUTDIR_]] [_OPTION_]... --module _KERNELMODULE_...
 
 DESCRIPTION
 -----------
@@ -41,6 +41,11 @@ OPTIONS
 
 **-r**, **--sysrootdir**::
     Install all files from _SYSROOTDIR_
+
+**-B**, **--dracutdir** _DRACUTDIR_::
+    Allow installing files from the dracut installation at _DRACUTDIR_ in
+    addition to _SYSROOTDIR_ (needed when using dracut installed on the host,
+    outside _SYSROOTDIR_). Only has an effect if **--sysrootdir** is used.
 
 **-a**, **--all**::
     Install all _SOURCE_ arguments to _DESTROOTDIR_

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -81,6 +81,8 @@ static bool no_xattr = false;
 static char *destrootdir = NULL;
 static char *sysrootdir = NULL;
 static size_t sysrootdirlen = 0;
+static char *dracutdir = NULL;
+static size_t dracutdirlen = 0;
 static char *kerneldir = NULL;
 static size_t kerneldirlen = 0;
 static char **firmwaredirs = NULL;
@@ -1401,7 +1403,10 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
                         fullsrcpath = strdup(orig_src);
                 } else {
                         src = orig_src;
-                        _asprintf(&fullsrcpath, "%s%s", sysrootdir, src);
+                        if (dracutdirlen && strncmp(orig_src, dracutdir, dracutdirlen) == 0)
+                                fullsrcpath = strdup(orig_src);
+                        else
+                                _asprintf(&fullsrcpath, "%s%s", sysrootdir, src);
                 }
                 if (strncmp(orig_dst, sysrootdir, sysrootdirlen) == 0)
                         dst = orig_dst + sysrootdirlen;
@@ -1587,9 +1592,9 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
 static void usage(int status)
 {
         /*                                                                                */
-        printf("Usage: %s -D DESTROOTDIR [-r SYSROOTDIR] [OPTION]... -a SOURCE...\n"
-               "or: %s -D DESTROOTDIR [-r SYSROOTDIR] [OPTION]... SOURCE DEST\n"
-               "or: %s -D DESTROOTDIR [-r SYSROOTDIR] [OPTION]... -m KERNELMODULE [KERNELMODULE …]\n"
+        printf("Usage: %s -D DESTROOTDIR [-r SYSROOTDIR [-B DRACUTDIR]] [OPTION]... -a SOURCE...\n"
+               "or: %s -D DESTROOTDIR [-r SYSROOTDIR [-B DRACUTDIR]] [OPTION]... SOURCE DEST\n"
+               "or: %s -D DESTROOTDIR [-r SYSROOTDIR [-B DRACUTDIR]] [OPTION]... -m KERNELMODULE [KERNELMODULE …]\n"
                "\n"
                "Install SOURCE (from rootfs or SYSROOTDIR) to DEST in DESTROOTDIR with all needed dependencies.\n"
                "\n"
@@ -1600,6 +1605,9 @@ static void usage(int status)
                "\n"
                "  -D --destrootdir  Install all files to DESTROOTDIR as the root\n"
                "  -r --sysrootdir   Install all files from SYSROOTDIR\n"
+               "  -B --dracutdir    Allow installing files from the dracut installation\n"
+               "                    at DRACUTDIR in addition to SYSROOTDIR (needed when\n"
+               "                    using dracut installed outside SYSROOTDIR)\n"
                "  -a --all          Install all SOURCE arguments to DESTROOTDIR\n"
                "  -o --optional     If SOURCE does not exist, do not fail\n"
                "  -d --dir          SOURCE is a directory\n"
@@ -1678,10 +1686,11 @@ static int parse_argv(int argc, char *argv[])
                 {"firmwaredirs", required_argument, NULL, ARG_FIRMWAREDIRS},
                 {"json-supported", no_argument, NULL, ARG_JSON_SUPPORTED},
                 {"dry-run", no_argument, NULL, 'n'},
+                {"dracutdir", required_argument, NULL, 'B'},
                 {NULL, 0, NULL, 0}
         };
 
-        while ((c = getopt_long(argc, argv, "madfhlL:oD:Hr:Rp:P:s:S:N:vn", options, NULL)) != -1) {
+        while ((c = getopt_long(argc, argv, "madfhlL:oD:Hr:Rp:P:s:S:N:vnB:", options, NULL)) != -1) {
                 switch (c) {
                 case ARG_VERSION:
                         puts(PROGRAM_VERSION_STRING);
@@ -1795,6 +1804,17 @@ static int parse_argv(int argc, char *argv[])
 #endif
                 case 'n':
                         arg_dry_run = true;
+                        break;
+                case 'B':
+                        dracutdir = optarg;
+                        dracutdirlen = strlen(dracutdir);
+                        if (dracutdirlen < 1) {
+                                log_error("dracutdir is set but empty!");
+                                exit(EXIT_FAILURE);
+                        }
+                        /* ignore trailing '/' */
+                        if (dracutdir[dracutdirlen-1] == '/')
+                                dracutdirlen--;
                         break;
                 default:
                         usage(EXIT_FAILURE);


### PR DESCRIPTION
In a cross-build situation where a build host is preparing an initramfs for a target system (which may have a different architecture) there is no reason to install Dracut into the sysroot, and for embedded systems where rootfs size should be kept low it is explicitly undesirable to do so. Installing `dracut-util` (for use in the initramfs) and possibly `dracut-extractinitrd` (if `dracut-initramfs-restore.sh` is used) is sufficient.

Scripts, udev rules, and systemd units (if applicable) need to be installed from the modules directories that are part of Dracut as installed on the host. The new `--dracutdir`/`-B` parameter for `dracut-install` allows installing from the specified directory if `--sysroot` is used, the `inst{,_script,_simple}` helper functions use the new parameter if `dracutsysrootdir` is set. Binaries must still come from the sysroot.

Split out of #2588.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
