### PR TITLE
fix(extractinitrd): create leading directories when extracting a selection

### DIFF
--- a/src/extractinitrd/extractinitrd.c
+++ b/src/extractinitrd/extractinitrd.c
@@ -719,8 +719,12 @@ int main(int argc, char **argv)
                 cpio_optv[cpio_optc++] = "-t";
         if (verbose)
                 cpio_optv[cpio_optc++] = "-v";
-        if (!do_list && !to_stdout && cpio_supports_no_absolute_filenames())
-                cpio_optv[cpio_optc++] = "--no-absolute-filenames";
+        if (!do_list && !to_stdout) {
+                cpio_optv[cpio_optc++] = "-d";
+
+                if (cpio_supports_no_absolute_filenames())
+                        cpio_optv[cpio_optc++] = "--no-absolute-filenames";
+        }
         while (optind < argc)
                 cpio_optv[cpio_optc++] = argv[optind++];
 


### PR DESCRIPTION
cpio without the `-d/--make-directories` option does not create leading directories where needed (see cpio(1)). Extracting a selection of files fails if the archive entry for a parent directory is not part of that. E.g.:

```
$ sudo dracutbasedir=. ./lsinitrd.sh --unpack /boot/initrd etc/cmdline.d/*
cpio: etc/cmdline.d/00-btrfs.conf: Cannot open: No such file or directory
cpio: etc/cmdline.d/90crypt.conf: Cannot open: No such file or directory
cpio: etc/cmdline.d/95resume.conf: Cannot open: No such file or directory
cpio: etc/cmdline.d/95root-dev.conf: Cannot open: No such file or directory
dracut-extractinitrd: cpio failed
```

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
